### PR TITLE
[DDW-949] Integrate the Search component into the Stake Pools page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Features
 
+- Implemented Stake Pools page ([PR 19](https://github.com/input-output-hk/cardano-explorer-app/pull/19), [PR 28](https://github.com/input-output-hk/cardano-explorer-app/pull/28), [PR 33](https://github.com/input-output-hk/cardano-explorer-app/pull/33))
 - Implement address details page design story ([PR 30](https://github.com/input-output-hk/cardano-explorer-app/pull/30))
 - Implement main page design story ([PR 26](https://github.com/input-output-hk/cardano-explorer-app/pull/26))
 - Implement no search results component ([PR 25](https://github.com/input-output-hk/cardano-explorer-app/pull/25))

--- a/source/features/stake-pools/components/StakePoolsSearch.scss
+++ b/source/features/stake-pools/components/StakePoolsSearch.scss
@@ -1,3 +1,4 @@
 .stakePoolsSearchContainer {
-  margin: 30px 0 70px;
+  margin: 40px auto 30px;
+  max-width: 440px;
 }

--- a/source/features/stake-pools/components/StakePoolsSearch.tsx
+++ b/source/features/stake-pools/components/StakePoolsSearch.tsx
@@ -1,15 +1,16 @@
 import { observer } from 'mobx-react-lite';
 import { Input } from 'react-polymorph/lib/components/Input';
+import Search from '../../widgets/search/components/Search';
 import { IStakePoolsSearchProps } from '../types';
 import styles from './StakePoolsSearch.scss';
 
 const StakePoolsSearch = ({ search, onSearch }: IStakePoolsSearchProps) => {
   return (
     <div className={styles.stakePoolsSearchContainer}>
-      <Input
+      <Search
         placeholder="Search for a specific stake pool"
-        value={search}
-        onChange={(v: string) => onSearch(v)}
+        onSearch={(v: string) => onSearch(v)}
+        title={false}
       />
     </div>
   );

--- a/source/features/widgets/search/components/Search.tsx
+++ b/source/features/widgets/search/components/Search.tsx
@@ -8,12 +8,13 @@ import styles from './Search.scss';
 
 export interface ISearchProps {
   placeholder?: string;
+  title?: string | boolean;
   brandType?: BrandType;
   onSearch: (value: string) => void;
 }
 
 const Search = (props: ISearchProps) => {
-  const { placeholder, brandType, onSearch } = props;
+  const { placeholder, brandType, onSearch, title } = props;
   const [searchValue, setSearchValue] = useState('');
   const brandTypeStyle =
     brandType === BrandType.ENLARGED
@@ -23,7 +24,7 @@ const Search = (props: ISearchProps) => {
 
   return (
     <div className={searchContainerStyles}>
-      <h2 className={styles.searchTitle}>Search</h2>
+      {title && <h2 className={styles.searchTitle}>{title}</h2>}
       <div className={styles.searchContent}>
         <Input
           className={styles.searchInput}
@@ -49,6 +50,7 @@ const Search = (props: ISearchProps) => {
 Search.defaultProps = {
   brandType: BrandType.ENLARGED,
   placeholder: 'Search for epochs, blocks, addresses and transactions',
+  title: 'Search',
 };
 
 export default observer(Search);

--- a/source/pages/index.tsx
+++ b/source/pages/index.tsx
@@ -13,6 +13,7 @@ import Layout from '../layout/Layout';
 import styles from './index.scss';
 
 export { default as AddressPage } from './address';
+export { default as StakePoolsPage } from './stake-pools';
 
 if (environment.DEBUG) {
   debug.enable(environment.DEBUG);

--- a/stories/pages.stories.tsx
+++ b/stories/pages.stories.tsx
@@ -1,7 +1,8 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import IndexPage, { AddressPage } from '../source/pages';
+import IndexPage, { AddressPage, StakePoolsPage } from '../source/pages';
 
 storiesOf('Pages', module)
   .add('Main Page', () => <IndexPage />)
-  .add('Address Page', () => <AddressPage />);
+  .add('Address Page', () => <AddressPage />)
+  .add('Stake Pools Page', () => <StakePoolsPage />);


### PR DESCRIPTION
# Motivation
As a developer, I want to re-use components as much as possible

# Description
At the moment, the Stake Pools page is using a generic Input component for the search. We need to integrate the Cardano Explorer Search component once DDW-935 is done.

# Screenshot

![image](https://user-images.githubusercontent.com/1504716/67110502-49b6e200-f1a9-11e9-9cd2-55d52b2b67fa.png)

# Testing

* Go to the [`Stake Pools Page`](https://deploy-preview-33--cardano-explorer.netlify.com/?path=/story/pages--stake-pools-page) > Click the `Yes, show unmoderated content` button.