### PR TITLE
[DDW-1033] Add missing SCSS variables in the mainnet theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog
 
 ### Features
 
-- Included the mainnet theme variables and made it the default network ([PR 53](https://github.com/input-output-hk/cardano-explorer-app/pull/53))
+- Included the mainnet theme variables and made it the default network ([PR 53](https://github.com/input-output-hk/cardano-explorer-app/pull/53), [PR 54](https://github.com/input-output-hk/cardano-explorer-app/pull/54))
 - Implemented table component ([PR 43](https://github.com/input-output-hk/cardano-explorer-app/pull/43))
 - Implemented stake distribution table on the current epoch page ([PR 37](https://github.com/input-output-hk/cardano-explorer-app/pull/37))
 - Implemented block creation table to for previous epoch page ([PR 36](https://github.com/input-output-hk/cardano-explorer-app/pull/36))

--- a/source/styles/resources/variables-themes/variables-theme-mainnet.scss
+++ b/source/styles/resources/variables-themes/variables-theme-mainnet.scss
@@ -3,15 +3,15 @@
  * Variables for the `mainnet` theme.
  *
  */
-$transparent-color: transparent;
+$dotted-separator-color: #36395d;
+$error-color: #eb2256;
+$footer-text-color: rgba(31, 193, 195, 0.3);
 $primary-highlight-color: #1fc1c3;
 $primary-highlight-color-hover: #1db0b3;
 $primary-highlight-color-press: #1aa1a3;
-$secondary-highlight-color: #709cf0;
-$secondary-half-color: rgba(112, 156, 240, 0.5);
 $secondary-color: rgba(112, 156, 240, 0.3);
-$dotted-separator-color: #36395d;
-$footer-text-color: rgba(31, 193, 195, 0.3);
+$secondary-half-color: rgba(112, 156, 240, 0.5);
+$secondary-highlight-color: #709cf0;
 $spinner-circle-background-color: conic-gradient(
   rgba(31, 193, 195, 0),
   rgba(31, 193, 195, 0.2) 21%,
@@ -20,3 +20,4 @@ $spinner-circle-background-color: conic-gradient(
   rgba(31, 193, 195, 0),
   rgba(31, 193, 195, 0)
 );
+$transparent-color: transparent;


### PR DESCRIPTION
This PR adds missing SCSS variables in the mainnet theme:

```diff
@@ -3,15 +3,15 @@
 * Variables for the `mainnet` theme.
 *
 */
-$transparent-color: transparent;
+$dotted-separator-color: #36395d;
+$error-color: #eb2256;
+$footer-text-color: rgba(31, 193, 195, 0.3);
$primary-highlight-color: #1fc1c3;
$primary-highlight-color-hover: #1db0b3;
$primary-highlight-color-press: #1aa1a3;
-$secondary-highlight-color: #709cf0;
-$secondary-half-color: rgba(112, 156, 240, 0.5);
$secondary-color: rgba(112, 156, 240, 0.3);
-$dotted-separator-color: #36395d;
-$footer-text-color: rgba(31, 193, 195, 0.3);
+$secondary-half-color: rgba(112, 156, 240, 0.5);
+$secondary-highlight-color: #709cf0;
$spinner-circle-background-color: conic-gradient(
  rgba(31, 193, 195, 0),
  rgba(31, 193, 195, 0.2) 21%,
@ -20,3 +20,4 @@ $spinner-circle-background-color: conic-gradient(
  rgba(31, 193, 195, 0),
  rgba(31, 193, 195, 0)
);
+$transparent-color: transparent;
```