### PR TITLE
[DDW-1034] Trigger searches after component rendered

### DIFF
--- a/source/features/search/components/BlocksSearchResult.tsx
+++ b/source/features/search/components/BlocksSearchResult.tsx
@@ -1,20 +1,24 @@
 import { Observer } from 'mobx-react-lite';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useEffect } from 'react';
 import BlockSummary from '../../blocks/ui/BlockSummary';
 import { useSearchFeature } from '../index';
 
 export const BlocksSearchResult = () => {
   const { actions, store } = useSearchFeature();
   const router = useRouter();
-  const { query } = router;
-  if (query && query.id) {
-    const id = query.id as string;
-    actions.searchForBlockById.trigger({ id });
-  } else if (query && query.number) {
-    const num = parseInt(query.number as string, 10);
-    actions.searchForBlockByNumber.trigger({ number: num });
-  }
+
+  // Trigger search after component did render
+  useEffect(() => {
+    const { query } = router;
+    if (query && query.id) {
+      const id = query.id as string;
+      actions.searchForBlockById.trigger({ id });
+    } else if (query && query.number) {
+      const num = parseInt(query.number as string, 10);
+      actions.searchForBlockByNumber.trigger({ number: num });
+    }
+  });
   return (
     <Observer>
       {() => {

--- a/source/features/search/components/EpochsSearchResult.tsx
+++ b/source/features/search/components/EpochsSearchResult.tsx
@@ -1,6 +1,6 @@
 import { Observer } from 'mobx-react-lite';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useEffect } from 'react';
 import Container from '../../../widgets/container/Container';
 import BlockList from '../../blocks/ui/BlockList';
 import EpochSummary from '../../epochs/ui/EpochSummary';
@@ -44,11 +44,15 @@ const stakeDistribution = [
 export const EpochsSearchResult = () => {
   const { actions, store } = useSearchFeature();
   const router = useRouter();
-  const { query } = router;
-  if (query && query.number) {
-    const num = parseInt(query.number as string, 10);
-    actions.searchForEpochByNumber.trigger({ number: num });
-  }
+
+  // Trigger search after component did render
+  useEffect(() => {
+    const { query } = router;
+    if (query && query.number) {
+      const num = parseInt(query.number as string, 10);
+      actions.searchForEpochByNumber.trigger({ number: num });
+    }
+  });
   return (
     <Observer>
       {() => {

--- a/source/lib/Store.ts
+++ b/source/lib/Store.ts
@@ -2,17 +2,20 @@ import ActionBinding from './ActionBinding';
 import Reaction from './mobx/Reaction';
 
 export class Store {
+  public isRunning: boolean = false;
   private actionBindings: ActionBinding[] = [];
   private reactions: Reaction[] = [];
 
   public start() {
     this.startActions();
     this.startReactions();
+    this.isRunning = true;
   }
 
   public stop() {
     this.stopActions();
     this.stopReactions();
+    this.isRunning = false;
   }
 
   // ACTIONS


### PR DESCRIPTION
The problem we observed was that the search didn't 
work when you entered anything in the search bar 
and redirected to the search page. But in reality 
it was a race condition problem: the search 
component triggered the search in its render 
function and not using useEffect - which resulted 
in the action sometimes being dispatched before 
the search store was started (and thus the action 
was not handled)