### PR TITLE
Chore/cardano graphql 0.3.0 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,35 +2,4 @@ Changelog
 =========
 
 ## 0.1.0
-
-### Features
-
-- Included the mainnet theme variables and made it the default network ([PR 53](https://github.com/input-output-hk/cardano-explorer-app/pull/53), [PR 54](https://github.com/input-output-hk/cardano-explorer-app/pull/54))
-- Implemented table component ([PR 43](https://github.com/input-output-hk/cardano-explorer-app/pull/43))
-- Implemented stake distribution table on the current epoch page ([PR 37](https://github.com/input-output-hk/cardano-explorer-app/pull/37))
-- Implemented block creation table to for previous epoch page ([PR 36](https://github.com/input-output-hk/cardano-explorer-app/pull/36))
-- Implement pagination component ([PR 35](https://github.com/input-output-hk/cardano-explorer-app/pull/35))
-- Implemented unsupported browser component ([PR 29](https://github.com/input-output-hk/cardano-explorer-app/pull/29))
-- Implemented stake pools page ([PR 19](https://github.com/input-output-hk/cardano-explorer-app/pull/19), [PR 28](https://github.com/input-output-hk/cardano-explorer-app/pull/28), [PR 33](https://github.com/input-output-hk/cardano-explorer-app/pull/33))
-- Implement address details page design story ([PR 30](https://github.com/input-output-hk/cardano-explorer-app/pull/30))
-- Implement main page design story ([PR 26](https://github.com/input-output-hk/cardano-explorer-app/pull/26))
-- Implement no search results component ([PR 25](https://github.com/input-output-hk/cardano-explorer-app/pull/25))
-- Implement block details component ([PR 24](https://github.com/input-output-hk/cardano-explorer-app/pull/24))
-- Implement transaction details component ([PR 23](https://github.com/input-output-hk/cardano-explorer-app/pull/23))
-- Implement address info and transaction list components ([PR 22](https://github.com/input-output-hk/cardano-explorer-app/pull/22))
-- Implement blocks component ([PR 17](https://github.com/input-output-hk/cardano-explorer-app/pull/17/))
-- Implement epoch info component for epoch details page ([PR 15](https://github.com/input-output-hk/cardano-explorer-app/pull/15))
-- Implement epoch list component for main page ([PR 13](https://github.com/input-output-hk/cardano-explorer-app/pull/13))
-- Implement search component ([PR 12](https://github.com/input-output-hk/cardano-explorer-app/pull/12))
-- Implement header component ([PR 11](https://github.com/input-output-hk/cardano-explorer-app/pull/11))
-
-### Fixes
-
-- Upgraded **lodash** to version 4.17.13 ([PR 16](https://github.com/input-output-hk/cardano-explorer-app/pull/16))
-- Fixed dependencies vulnerabilities ([PR 31](https://github.com/input-output-hk/cardano-explorer-app/issues/31))
-- Fixed minor styling inconsistencies ([PR 34](https://github.com/input-output-hk/cardano-explorer-app/issues/34))
-
-### Chores
-
-- Added missing search component states ([PR 52](https://github.com/input-output-hk/cardano-explorer-app/pull/52))
-- Organized the CSS structure, global rules, and global variables ([PR 14](https://github.com/input-output-hk/cardano-explorer-app/pull/14), [PR 18](https://github.com/input-output-hk/cardano-explorer-app/pull/18))
+Initial pre-production release

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
 version: '3.7'
 services:
   api:
-    image: samjeston/cardano-graphql-dev:0.2.1
+    image: samjeston/cardano-graphql-dev:0.3.0
     restart: always
     environment:
       - HASURA_URI=http://hasura:8080/v1/graphql
     ports:
       - ${API_PORT:-3100}:3100
   hasura:
-    image: samjeston/cardano-graphql-hasura:0.2.1
+    image: samjeston/cardano-graphql-hasura:0.3.0
     depends_on:
       - "postgres"
     restart: always
@@ -17,5 +17,5 @@ services:
       - HASURA_GRAPHQL_ENABLE_CONSOLE=false
       - HASURA_GRAPHQL_ENABLED_LOG_TYPES=startup
   postgres:
-    image: samjeston/cardano-graphql-pgseed:0.2.1
+    image: samjeston/cardano-graphql-pgseed:0.3.0
     restart: always

--- a/generated/typings/graphql-schema.d.ts
+++ b/generated/typings/graphql-schema.d.ts
@@ -623,11 +623,11 @@ export type Uxto_Sum_Fields = {
   __typename?: 'Uxto_sum_fields',
   value?: Maybe<Scalars['String']>,
 };
-export type BlockDetailsFragment = ({ __typename?: 'Block' } & Pick<Block, 'createdAt' | 'id' | 'merkelRootHash' | 'number' | 'size' | 'slotNo'> & { epoch: Maybe<({ __typename?: 'Epoch' } & Pick<Epoch, 'number'>)>, previousBlock: Maybe<({ __typename?: 'Block' } & Pick<Block, 'id' | 'number'>)>, transactions_aggregate: ({ __typename?: 'Transaction_aggregate' } & { aggregate: Maybe<({ __typename?: 'Transaction_aggregate_fields' } & Pick<Transaction_Aggregate_Fields, 'count'>)> }) });
+export type BlockDetailsFragment = ({ __typename?: 'Block' } & Pick<Block, 'createdAt' | 'createdBy' | 'id' | 'merkelRootHash' | 'number' | 'size' | 'slotNo'> & { epoch: Maybe<({ __typename?: 'Epoch' } & Pick<Epoch, 'number'>)>, previousBlock: Maybe<({ __typename?: 'Block' } & Pick<Block, 'id' | 'number'>)>, transactions_aggregate: ({ __typename?: 'Transaction_aggregate' } & { aggregate: Maybe<({ __typename?: 'Transaction_aggregate_fields' } & Pick<Transaction_Aggregate_Fields, 'count'> & { sum: Maybe<({ __typename?: 'Transaction_sum_fields' } & Pick<Transaction_Sum_Fields, 'totalOutput'>)> })> }) });
 
 export type BlockInfoFragment = ({ __typename?: 'Block' } & Pick<Block, 'id' | 'number' | 'size' | 'slotNo'>);
 
-export type BlockOverviewFragment = ({ __typename?: 'Block' } & Pick<Block, 'createdAt' | 'id' | 'number' | 'size' | 'slotNo'> & { epoch: Maybe<({ __typename?: 'Epoch' } & Pick<Epoch, 'number'>)>, transactions_aggregate: ({ __typename?: 'Transaction_aggregate' } & { aggregate: Maybe<({ __typename?: 'Transaction_aggregate_fields' } & Pick<Transaction_Aggregate_Fields, 'count'>)> }) });
+export type BlockOverviewFragment = ({ __typename?: 'Block' } & Pick<Block, 'createdAt' | 'createdBy' | 'id' | 'number' | 'size' | 'slotNo'> & { epoch: Maybe<({ __typename?: 'Epoch' } & Pick<Epoch, 'number'>)>, transactions_aggregate: ({ __typename?: 'Transaction_aggregate' } & { aggregate: Maybe<({ __typename?: 'Transaction_aggregate_fields' } & Pick<Transaction_Aggregate_Fields, 'count'> & { sum: Maybe<({ __typename?: 'Transaction_sum_fields' } & Pick<Transaction_Sum_Fields, 'totalOutput'>)> })> }) });
 
 export type GetBlocksInRangeQueryVariables = {
   lower: Scalars['Int'],

--- a/generated/typings/graphql-schema.d.ts
+++ b/generated/typings/graphql-schema.d.ts
@@ -6,14 +6,14 @@ export type Scalars = {
   Boolean: boolean,
   Int: number,
   Float: number,
-  /** Hex encoded hash32 string, 64 characters */
-  Hash32HexString: any,
+  /** The `DateTime` scalar represents a date and time following the ISO 8601 standard */
+  DateTime: any,
   /** The `BigInt` scalar type represents non-fractional signed whole numeric values.
    * BigInt can represent values between -(2^53) + 1 and 2^53 - 1. 
  */
   BigInt: any,
-  /** The `DateTime` scalar represents a date and time following the ISO 8601 standard */
-  DateTime: any,
+  /** Hex encoded hash32 string, 64 characters */
+  Hash32HexString: any,
   /** LoveLaces, the atomic unit of ADA */
   LoveLaces: any,
   /** 0-100 */
@@ -39,23 +39,36 @@ export type BigInt_Comparison_Exp = {
 
 export type Block = {
   __typename?: 'Block',
+  createdAt: Scalars['DateTime'],
+  createdBy: Scalars['String'],
+  /** Genesis block does not belong to the 0th epoch, therefore it could be null */
   epoch?: Maybe<Epoch>,
-  fees?: Maybe<Scalars['String']>,
+  fees: Scalars['String'],
   id: Scalars['Hash32HexString'],
+  /** Ouroboros Classic Epoch Boundary blocks (EBB) do not have a merkel root */
   merkelRootHash?: Maybe<Scalars['Hash32HexString']>,
-  /** Genesis and Epoch Boundary Blocks (EBBs) do not have numbers */
+  /** Ouroboros Classic Epoch Boundary blocks (EBB) do not have a block number */
   number?: Maybe<Scalars['Int']>,
+  /** Ouroboros Classic Epoch Boundary blocks (EBB) do not have a slot number */
   slotNo?: Maybe<Scalars['Int']>,
+  /** Ouroboros Classic Epoch Boundary blocks (EBB) do not have a slot number */
   slotWithinEpoch?: Maybe<Scalars['Int']>,
   previousBlock?: Maybe<Block>,
   size: Scalars['Int'],
-  createdAt: Scalars['DateTime'],
   transactions: Array<Maybe<Transaction>>,
   transactions_aggregate: Transaction_Aggregate,
 };
 
 
 export type BlockTransactionsArgs = {
+  limit?: Maybe<Scalars['Int']>,
+  order_by?: Maybe<Array<Transaction_Order_By>>,
+  offset?: Maybe<Scalars['Int']>,
+  where?: Maybe<Transaction_Bool_Exp>
+};
+
+
+export type BlockTransactions_AggregateArgs = {
   limit?: Maybe<Scalars['Int']>,
   order_by?: Maybe<Array<Transaction_Order_By>>,
   offset?: Maybe<Scalars['Int']>,
@@ -83,9 +96,20 @@ export type Block_Avg_Fields = {
 };
 
 export type Block_Bool_Exp = {
-  id?: Maybe<Hash32HexString_Comparison_Exp>,
+  _and?: Maybe<Array<Maybe<Block_Bool_Exp>>>,
+  _not?: Maybe<Block_Bool_Exp>,
+  _or?: Maybe<Array<Maybe<Block_Bool_Exp>>>,
+  createdAt?: Maybe<Date_Comparison_Exp>,
+  createdBy?: Maybe<Text_Comparison_Exp>,
   epoch?: Maybe<Epoch_Bool_Exp>,
+  fees?: Maybe<BigInt_Comparison_Exp>,
+  id?: Maybe<Hash32HexString_Comparison_Exp>,
   number?: Maybe<Int_Comparison_Exp>,
+  previousBlock?: Maybe<Block_Bool_Exp>,
+  size?: Maybe<Int_Comparison_Exp>,
+  slotNo?: Maybe<Int_Comparison_Exp>,
+  slotWithinEpoch?: Maybe<Int_Comparison_Exp>,
+  transactions?: Maybe<Transaction_Bool_Exp>,
 };
 
 export type Block_Max_Fields = {
@@ -101,8 +125,14 @@ export type Block_Min_Fields = {
 };
 
 export type Block_Order_By = {
-  number?: Maybe<Order_By>,
+  createdAt?: Maybe<Order_By>,
+  createdBy?: Maybe<Order_By>,
+  epoch?: Maybe<Epoch_Order_By>,
+  fees?: Maybe<Order_By>,
+  number?: Maybe<Order_By_With_Nulls>,
   size?: Maybe<Order_By>,
+  slotNo?: Maybe<Order_By_With_Nulls>,
+  slotWithinEpoch?: Maybe<Order_By_With_Nulls>,
 };
 
 export type Block_Sum_Fields = {
@@ -145,6 +175,9 @@ export type Coin_Avg_Fields = {
 };
 
 export type Coin_Bool_Exp = {
+  _and?: Maybe<Array<Maybe<Coin_Bool_Exp>>>,
+  _not?: Maybe<Coin_Bool_Exp>,
+  _or?: Maybe<Array<Maybe<Coin_Bool_Exp>>>,
   address?: Maybe<Text_Comparison_Exp>,
   value?: Maybe<BigInt_Comparison_Exp>,
 };
@@ -185,17 +218,25 @@ export type Date_Comparison_Exp = {
 
 export type Epoch = {
   __typename?: 'Epoch',
-  blocks?: Maybe<Array<Maybe<Block>>>,
+  blocks: Array<Block>,
   blocks_aggregate: Block_Aggregate,
   output: Scalars['String'],
   number: Scalars['Int'],
-  transactionsCount?: Maybe<Scalars['String']>,
+  transactionsCount: Scalars['String'],
   startedAt: Scalars['DateTime'],
   lastBlockTime: Scalars['DateTime'],
 };
 
 
 export type EpochBlocksArgs = {
+  limit?: Maybe<Scalars['Int']>,
+  order_by?: Maybe<Array<Block_Order_By>>,
+  offset?: Maybe<Scalars['Int']>,
+  where?: Maybe<Block_Bool_Exp>
+};
+
+
+export type EpochBlocks_AggregateArgs = {
   limit?: Maybe<Scalars['Int']>,
   order_by?: Maybe<Array<Block_Order_By>>,
   offset?: Maybe<Scalars['Int']>,
@@ -216,7 +257,13 @@ export type Epoch_Aggregate_Fields = {
 };
 
 export type Epoch_Bool_Exp = {
+  _and?: Maybe<Array<Maybe<Epoch_Bool_Exp>>>,
+  _not?: Maybe<Epoch_Bool_Exp>,
+  _or?: Maybe<Array<Maybe<Epoch_Bool_Exp>>>,
+  blocks?: Maybe<Block_Bool_Exp>,
   number?: Maybe<Int_Comparison_Exp>,
+  output?: Maybe<Text_Comparison_Exp>,
+  transactionsCount?: Maybe<Text_Comparison_Exp>,
 };
 
 export type Epoch_Max_Fields = {
@@ -233,9 +280,9 @@ export type Epoch_Min_Fields = {
 };
 
 export type Epoch_Order_By = {
-  blockCount?: Maybe<Order_By>,
   number?: Maybe<Order_By>,
-  fees?: Maybe<Order_By>,
+  output?: Maybe<Order_By>,
+  transactionsCount?: Maybe<Order_By>,
 };
 
 export type Epoch_Sum_Fields = {
@@ -317,15 +364,26 @@ export type Percentage_Comparison_Exp = {
 export type Query = {
   __typename?: 'Query',
   blocks: Array<Maybe<Block>>,
+  blocks_aggregate: Block_Aggregate,
   epochs: Array<Maybe<Epoch>>,
   epochs_aggregate: Epoch_Aggregate,
   cardano?: Maybe<Cardano>,
   transactions: Array<Maybe<Transaction>>,
-  utxoSet: Array<Maybe<TransactionOutput>>,
+  transactions_aggregate: Transaction_Aggregate,
+  utxos: Array<Maybe<TransactionOutput>>,
+  utxos_aggregate: Utxo_Aggregate,
 };
 
 
 export type QueryBlocksArgs = {
+  limit?: Maybe<Scalars['Int']>,
+  order_by?: Maybe<Array<Block_Order_By>>,
+  offset?: Maybe<Scalars['Int']>,
+  where?: Maybe<Block_Bool_Exp>
+};
+
+
+export type QueryBlocks_AggregateArgs = {
   limit?: Maybe<Scalars['Int']>,
   order_by?: Maybe<Array<Block_Order_By>>,
   offset?: Maybe<Scalars['Int']>,
@@ -357,11 +415,27 @@ export type QueryTransactionsArgs = {
 };
 
 
-export type QueryUtxoSetArgs = {
+export type QueryTransactions_AggregateArgs = {
+  limit?: Maybe<Scalars['Int']>,
+  order_by?: Maybe<Array<Transaction_Order_By>>,
+  offset?: Maybe<Scalars['Int']>,
+  where?: Maybe<Transaction_Bool_Exp>
+};
+
+
+export type QueryUtxosArgs = {
   limit?: Maybe<Scalars['Int']>,
   order_by?: Maybe<Array<Utxo_Order_By>>,
   offset?: Maybe<Scalars['Int']>,
-  where: Utxo_Bool_Exp
+  where?: Maybe<Utxo_Bool_Exp>
+};
+
+
+export type QueryUtxos_AggregateArgs = {
+  limit?: Maybe<Scalars['Int']>,
+  order_by?: Maybe<Array<Utxo_Order_By>>,
+  offset?: Maybe<Scalars['Int']>,
+  where?: Maybe<Utxo_Bool_Exp>
 };
 
 export type Text_Comparison_Exp = {
@@ -404,7 +478,23 @@ export type TransactionInputsArgs = {
 };
 
 
+export type TransactionInputs_AggregateArgs = {
+  limit?: Maybe<Scalars['Int']>,
+  order_by?: Maybe<Array<Maybe<Coin_Order_By>>>,
+  offset?: Maybe<Scalars['Int']>,
+  where?: Maybe<Coin_Bool_Exp>
+};
+
+
 export type TransactionOutputsArgs = {
+  limit?: Maybe<Scalars['Int']>,
+  order_by?: Maybe<Array<Maybe<Coin_Order_By>>>,
+  offset?: Maybe<Scalars['Int']>,
+  where?: Maybe<Coin_Bool_Exp>
+};
+
+
+export type TransactionOutputs_AggregateArgs = {
   limit?: Maybe<Scalars['Int']>,
   order_by?: Maybe<Array<Maybe<Coin_Order_By>>>,
   offset?: Maybe<Scalars['Int']>,
@@ -432,8 +522,16 @@ export type Transaction_Avg_Fields = {
 };
 
 export type Transaction_Bool_Exp = {
-  id?: Maybe<Hash32HexString_Comparison_Exp>,
+  _and?: Maybe<Array<Maybe<Transaction_Bool_Exp>>>,
+  _not?: Maybe<Transaction_Bool_Exp>,
+  _or?: Maybe<Array<Maybe<Transaction_Bool_Exp>>>,
   block?: Maybe<Block_Bool_Exp>,
+  fee?: Maybe<BigInt_Comparison_Exp>,
+  id?: Maybe<Hash32HexString_Comparison_Exp>,
+  includedAt?: Maybe<Date_Comparison_Exp>,
+  inputs?: Maybe<Coin_Bool_Exp>,
+  outputs?: Maybe<Coin_Bool_Exp>,
+  totalOutput?: Maybe<Text_Comparison_Exp>,
 };
 
 export type Transaction_Max_Fields = {
@@ -450,8 +548,9 @@ export type Transaction_Min_Fields = {
 
 export type Transaction_Order_By = {
   block?: Maybe<Order_By>,
-  includedAt?: Maybe<Order_By>,
   fee?: Maybe<Order_By>,
+  includedAt?: Maybe<Order_By>,
+  totalOutput?: Maybe<Order_By>,
 };
 
 export type Transaction_Sum_Fields = {
@@ -477,12 +576,52 @@ export type TransactionOutput = {
 };
 
 
+export type Utxo_Aggregate = {
+  __typename?: 'Utxo_aggregate',
+  aggregate?: Maybe<Utxo_Aggregate_Fields>,
+};
+
+export type Utxo_Aggregate_Fields = {
+  __typename?: 'Utxo_aggregate_fields',
+  avg?: Maybe<Uxto_Avg_Fields>,
+  count?: Maybe<Scalars['Int']>,
+  max?: Maybe<Uxto_Max_Fields>,
+  min?: Maybe<Uxto_Min_Fields>,
+  sum?: Maybe<Uxto_Sum_Fields>,
+};
+
 export type Utxo_Bool_Exp = {
+  _and?: Maybe<Array<Maybe<Utxo_Bool_Exp>>>,
+  _not?: Maybe<Utxo_Bool_Exp>,
+  _or?: Maybe<Array<Maybe<Utxo_Bool_Exp>>>,
   address?: Maybe<Text_Comparison_Exp>,
+  value?: Maybe<Text_Comparison_Exp>,
 };
 
 export type Utxo_Order_By = {
   address?: Maybe<Order_By>,
+  value?: Maybe<Order_By>,
+  index?: Maybe<Order_By>,
+};
+
+export type Uxto_Avg_Fields = {
+  __typename?: 'Uxto_avg_fields',
+  value?: Maybe<Scalars['String']>,
+};
+
+export type Uxto_Max_Fields = {
+  __typename?: 'Uxto_max_fields',
+  value?: Maybe<Scalars['String']>,
+};
+
+export type Uxto_Min_Fields = {
+  __typename?: 'Uxto_min_fields',
+  value?: Maybe<Scalars['String']>,
+};
+
+export type Uxto_Sum_Fields = {
+  __typename?: 'Uxto_sum_fields',
+  value?: Maybe<Scalars['String']>,
 };
 export type BlockDetailsFragment = ({ __typename?: 'Block' } & Pick<Block, 'createdAt' | 'id' | 'merkelRootHash' | 'number' | 'size' | 'slotNo'> & { epoch: Maybe<({ __typename?: 'Epoch' } & Pick<Epoch, 'number'>)>, previousBlock: Maybe<({ __typename?: 'Block' } & Pick<Block, 'id' | 'number'>)>, transactions_aggregate: ({ __typename?: 'Transaction_aggregate' } & { aggregate: Maybe<({ __typename?: 'Transaction_aggregate_fields' } & Pick<Transaction_Aggregate_Fields, 'count'>)> }) });
 
@@ -505,7 +644,7 @@ export type GetLatestBlocksQueryVariables = {
 
 export type GetLatestBlocksQuery = ({ __typename?: 'Query' } & { blocks: Array<Maybe<({ __typename?: 'Block' } & BlockOverviewFragment)>> });
 
-export type EpochDetailsFragment = ({ __typename?: 'Epoch' } & { blocks: Maybe<Array<Maybe<({ __typename?: 'Block' } & BlockInfoFragment)>>> } & EpochOverviewFragment);
+export type EpochDetailsFragment = ({ __typename?: 'Epoch' } & { blocks: Array<({ __typename?: 'Block' } & BlockInfoFragment)> } & EpochOverviewFragment);
 
 export type EpochOverviewFragment = ({ __typename?: 'Epoch' } & Pick<Epoch, 'lastBlockTime' | 'number' | 'startedAt' | 'output' | 'transactionsCount'> & { blocks_aggregate: ({ __typename?: 'Block_aggregate' } & { aggregate: Maybe<({ __typename?: 'Block_aggregate_fields' } & Pick<Block_Aggregate_Fields, 'count'>)> }) });
 

--- a/next.config.js
+++ b/next.config.js
@@ -75,7 +75,9 @@ module.exports = withPlugins(
       DEBUG
     },
     webpack(config) {
-      config.plugins.push(new LodashModuleReplacementPlugin());
+      config.plugins.push(new LodashModuleReplacementPlugin({
+        paths: true
+      }));
 
       // Push DotEnv vars into client code
       config.plugins.push(

--- a/schema.graphql
+++ b/schema.graphql
@@ -22,20 +22,39 @@ input BigInt_comparison_exp {
 }
 
 type Block {
+  createdAt: DateTime!
+  createdBy: String!
+
+  """
+  Genesis block does not belong to the 0th epoch, therefore it could be null
+  """
   epoch: Epoch
-  fees: String
+  fees: String!
   id: Hash32HexString!
+
+  """
+  Ouroboros Classic Epoch Boundary blocks (EBB) do not have a merkel root
+  """
   merkelRootHash: Hash32HexString
 
-  """Genesis and Epoch Boundary Blocks (EBBs) do not have numbers"""
+  """
+  Ouroboros Classic Epoch Boundary blocks (EBB) do not have a block number
+  """
   number: Int
+
+  """
+  Ouroboros Classic Epoch Boundary blocks (EBB) do not have a slot number
+  """
   slotNo: Int
+
+  """
+  Ouroboros Classic Epoch Boundary blocks (EBB) do not have a slot number
+  """
   slotWithinEpoch: Int
   previousBlock: Block
   size: Int!
-  createdAt: DateTime!
   transactions(limit: Int, order_by: [Transaction_order_by!], offset: Int, where: Transaction_bool_exp): [Transaction]!
-  transactions_aggregate: Transaction_aggregate!
+  transactions_aggregate(limit: Int, order_by: [Transaction_order_by!], offset: Int, where: Transaction_bool_exp): Transaction_aggregate!
 }
 
 type Block_aggregate {
@@ -56,9 +75,20 @@ type Block_avg_fields {
 }
 
 input Block_bool_exp {
-  id: Hash32HexString_comparison_exp
+  _and: [Block_bool_exp]
+  _not: Block_bool_exp
+  _or: [Block_bool_exp]
+  createdAt: Date_comparison_exp
+  createdBy: text_comparison_exp
   epoch: Epoch_bool_exp
+  fees: BigInt_comparison_exp
+  id: Hash32HexString_comparison_exp
   number: Int_comparison_exp
+  previousBlock: Block_bool_exp
+  size: Int_comparison_exp
+  slotNo: Int_comparison_exp
+  slotWithinEpoch: Int_comparison_exp
+  transactions: Transaction_bool_exp
 }
 
 type Block_max_fields {
@@ -72,8 +102,14 @@ type Block_min_fields {
 }
 
 input Block_order_by {
-  number: order_by
+  createdAt: order_by
+  createdBy: order_by
+  epoch: Epoch_order_by
+  fees: order_by
+  number: order_by_with_nulls
   size: order_by
+  slotNo: order_by_with_nulls
+  slotWithinEpoch: order_by_with_nulls
 }
 
 type Block_sum_fields {
@@ -111,6 +147,9 @@ type Coin_avg_fields {
 }
 
 input Coin_bool_exp {
+  _and: [Coin_bool_exp]
+  _not: Coin_bool_exp
+  _or: [Coin_bool_exp]
   address: text_comparison_exp
   value: BigInt_comparison_exp
 }
@@ -153,11 +192,11 @@ The `DateTime` scalar represents a date and time following the ISO 8601 standard
 scalar DateTime
 
 type Epoch {
-  blocks(limit: Int, order_by: [Block_order_by!], offset: Int, where: Block_bool_exp): [Block]
-  blocks_aggregate: Block_aggregate!
+  blocks(limit: Int, order_by: [Block_order_by!], offset: Int, where: Block_bool_exp): [Block!]!
+  blocks_aggregate(limit: Int, order_by: [Block_order_by!], offset: Int, where: Block_bool_exp): Block_aggregate!
   output: String!
   number: Int!
-  transactionsCount: String
+  transactionsCount: String!
   startedAt: DateTime!
   lastBlockTime: DateTime!
 }
@@ -174,7 +213,13 @@ type Epoch_aggregate_fields {
 }
 
 input Epoch_bool_exp {
+  _and: [Epoch_bool_exp]
+  _not: Epoch_bool_exp
+  _or: [Epoch_bool_exp]
+  blocks: Block_bool_exp
   number: Int_comparison_exp
+  output: text_comparison_exp
+  transactionsCount: text_comparison_exp
 }
 
 type Epoch_max_fields {
@@ -189,9 +234,9 @@ type Epoch_min_fields {
 }
 
 input Epoch_order_by {
-  blockCount: order_by
   number: order_by
-  fees: order_by
+  output: order_by
+  transactionsCount: order_by
 }
 
 type Epoch_sum_fields {
@@ -289,11 +334,14 @@ input Percentage_comparison_exp {
 
 type Query {
   blocks(limit: Int, order_by: [Block_order_by!], offset: Int, where: Block_bool_exp): [Block]!
+  blocks_aggregate(limit: Int, order_by: [Block_order_by!], offset: Int, where: Block_bool_exp): Block_aggregate!
   epochs(limit: Int, order_by: [Epoch_order_by!], offset: Int, where: Epoch_bool_exp): [Epoch]!
   epochs_aggregate(limit: Int, order_by: [Epoch_order_by!], offset: Int, where: Epoch_bool_exp): Epoch_aggregate!
   cardano: Cardano
   transactions(limit: Int, order_by: [Transaction_order_by!], offset: Int, where: Transaction_bool_exp): [Transaction]!
-  utxoSet(limit: Int, order_by: [Utxo_order_by!], offset: Int, where: Utxo_bool_exp!): [TransactionOutput]!
+  transactions_aggregate(limit: Int, order_by: [Transaction_order_by!], offset: Int, where: Transaction_bool_exp): Transaction_aggregate!
+  utxos(limit: Int, order_by: [Utxo_order_by!], offset: Int, where: Utxo_bool_exp): [TransactionOutput]!
+  utxos_aggregate(limit: Int, order_by: [Utxo_order_by!], offset: Int, where: Utxo_bool_exp): Utxo_aggregate!
 }
 
 input text_comparison_exp {
@@ -319,9 +367,9 @@ type Transaction {
   fee: String!
   id: Hash32HexString!
   inputs(limit: Int, order_by: [Coin_order_by], offset: Int, where: Coin_bool_exp): [TransactionInput!]!
-  inputs_aggregate: Coin_aggregate
+  inputs_aggregate(limit: Int, order_by: [Coin_order_by], offset: Int, where: Coin_bool_exp): Coin_aggregate
   outputs(limit: Int, order_by: [Coin_order_by], offset: Int, where: Coin_bool_exp): [TransactionOutput!]!
-  outputs_aggregate: Coin_aggregate
+  outputs_aggregate(limit: Int, order_by: [Coin_order_by], offset: Int, where: Coin_bool_exp): Coin_aggregate
   totalOutput: String!
   includedAt: DateTime!
 }
@@ -344,8 +392,16 @@ type Transaction_avg_fields {
 }
 
 input Transaction_bool_exp {
-  id: Hash32HexString_comparison_exp
+  _and: [Transaction_bool_exp]
+  _not: Transaction_bool_exp
+  _or: [Transaction_bool_exp]
   block: Block_bool_exp
+  fee: BigInt_comparison_exp
+  id: Hash32HexString_comparison_exp
+  includedAt: Date_comparison_exp
+  inputs: Coin_bool_exp
+  outputs: Coin_bool_exp
+  totalOutput: text_comparison_exp
 }
 
 type Transaction_max_fields {
@@ -360,8 +416,9 @@ type Transaction_min_fields {
 
 input Transaction_order_by {
   block: order_by
-  includedAt: order_by
   fee: order_by
+  includedAt: order_by
+  totalOutput: order_by
 }
 
 type Transaction_sum_fields {
@@ -386,11 +443,45 @@ type TransactionOutput {
 """The `Upload` scalar type represents a file upload."""
 scalar Upload
 
+type Utxo_aggregate {
+  aggregate: Utxo_aggregate_fields
+}
+
+type Utxo_aggregate_fields {
+  avg: Uxto_avg_fields
+  count: Int
+  max: Uxto_max_fields
+  min: Uxto_min_fields
+  sum: Uxto_sum_fields
+}
+
 input Utxo_bool_exp {
+  _and: [Utxo_bool_exp]
+  _not: Utxo_bool_exp
+  _or: [Utxo_bool_exp]
   address: text_comparison_exp
+  value: text_comparison_exp
 }
 
 input Utxo_order_by {
   address: order_by
+  value: order_by
+  index: order_by
+}
+
+type Uxto_avg_fields {
+  value: String
+}
+
+type Uxto_max_fields {
+  value: String
+}
+
+type Uxto_min_fields {
+  value: String
+}
+
+type Uxto_sum_fields {
+  value: String
 }
 

--- a/source/environment.ts
+++ b/source/environment.ts
@@ -17,5 +17,5 @@ export const environment = {
   DEBUG: process.env.DEBUG || 'false',
   IS_CLIENT: isNavigatorDefined,
   IS_SERVER: !isNavigatorDefined,
-  REAL_TIME_FACTOR: Number(process.env.REAL_TIME_FACTOR) || 1,
+  REAL_TIME_FACTOR: Number(process.env.REAL_TIME_FACTOR),
 };

--- a/source/features/blocks/api/BlockDetails.graphql
+++ b/source/features/blocks/api/BlockDetails.graphql
@@ -1,5 +1,6 @@
 fragment BlockDetails on Block {
   createdAt
+  createdBy
   id
   merkelRootHash
   number
@@ -15,6 +16,9 @@ fragment BlockDetails on Block {
   transactions_aggregate {
     aggregate {
       count
+      sum {
+        totalOutput
+      }
     }
   }
 }

--- a/source/features/blocks/api/BlockDetails.graphql
+++ b/source/features/blocks/api/BlockDetails.graphql
@@ -7,7 +7,7 @@ fragment BlockDetails on Block {
   size
   epoch {
     number
-  },
+  }
   previousBlock {
     id
     number

--- a/source/features/blocks/api/BlockOverview.graphql
+++ b/source/features/blocks/api/BlockOverview.graphql
@@ -1,5 +1,6 @@
 fragment BlockOverview on Block {
   createdAt
+  createdBy
   id
   number
   size
@@ -10,6 +11,9 @@ fragment BlockOverview on Block {
   transactions_aggregate {
     aggregate {
       count
+      sum {
+        totalOutput
+      }
     }
   }
 }

--- a/source/features/blocks/api/transformers.ts
+++ b/source/features/blocks/api/transformers.ts
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import {
   BlockDetailsFragment,
   BlockInfoFragment,
@@ -21,23 +22,15 @@ export const blockOverviewTransformer = (
     blockCreatorPrefix === 'SlotLeader-'
       ? b.createdBy.substring(12, 18)
       : b.createdBy;
-  const { transactions_aggregate } = b;
   return {
     ...blockInfoTransformer(b),
     createdAt: b.createdAt,
     createdBy,
     epoch: (b.epoch && b.epoch.number) || 0,
     output: lovelacesToAda(
-      (transactions_aggregate.aggregate &&
-        transactions_aggregate.aggregate.sum &&
-        transactions_aggregate.aggregate.sum.totalOutput) ||
-        0
+      get(b, 'transactions_aggregate.aggregate.sum.totalOutput', 0)
     ),
-    transactions:
-      (transactions_aggregate &&
-        transactions_aggregate.aggregate &&
-        transactions_aggregate.aggregate.count) ||
-      0,
+    transactions: get(b, 'transactions_aggregate.aggregate.count', 0),
   };
 };
 

--- a/source/features/blocks/api/transformers.ts
+++ b/source/features/blocks/api/transformers.ts
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import {
   BlockDetailsFragment,
   BlockInfoFragment,
@@ -22,15 +21,23 @@ export const blockOverviewTransformer = (
     blockCreatorPrefix === 'SlotLeader-'
       ? b.createdBy.substring(12, 18)
       : b.createdBy;
+  const { transactions_aggregate } = b;
   return {
     ...blockInfoTransformer(b),
     createdAt: b.createdAt,
     createdBy,
-    epoch: get(b, 'epoch.number', 0),
+    epoch: (b.epoch && b.epoch.number) || 0,
     output: lovelacesToAda(
-      get(b, 'transactions_aggregate.aggregate.sum.totalOutput', 0)
+      (transactions_aggregate.aggregate &&
+        transactions_aggregate.aggregate.sum &&
+        transactions_aggregate.aggregate.sum.totalOutput) ||
+        0
     ),
-    transactions: get(b, 'transactions_aggregate.aggregate.count', 0),
+    transactions:
+      (transactions_aggregate &&
+        transactions_aggregate.aggregate &&
+        transactions_aggregate.aggregate.count) ||
+      0,
   };
 };
 
@@ -39,7 +46,7 @@ export const blockDetailsTransformer = (
 ): IBlockDetailed => ({
   ...blockOverviewTransformer(b),
   confirmations: 1, // TODO: Calculate confirmations using Cardano.blockHeight
-  merkleRoot: get(b, 'merkelRootHash', ''),
+  merkleRoot: b.merkelRootHash || '',
   nextBlock: '', // TODO: missing API data
-  prevBlock: get(b, 'previousBlock.id', ''),
+  prevBlock: (b.previousBlock && b.previousBlock.id) || '',
 });

--- a/source/features/blocks/api/transformers.ts
+++ b/source/features/blocks/api/transformers.ts
@@ -1,13 +1,15 @@
+import { get } from 'lodash';
 import {
   BlockDetailsFragment,
   BlockInfoFragment,
   BlockOverviewFragment,
 } from '../../../../generated/typings/graphql-schema';
+import { lovelacesToAda } from '../../../lib/unit-converters';
 import { IBlockDetailed, IBlockInfo, IBlockOverview } from '../types';
 
 export const blockInfoTransformer = (b: BlockInfoFragment): IBlockInfo => ({
-  id: b.id ? b.id : '',
-  number: b.number ? b.number : 0,
+  id: b.id,
+  number: b.number || 0,
   size: b.size,
   slotNo: b.slotNo ? b.slotNo : 0,
 });
@@ -15,19 +17,20 @@ export const blockInfoTransformer = (b: BlockInfoFragment): IBlockInfo => ({
 export const blockOverviewTransformer = (
   b: BlockOverviewFragment
 ): IBlockOverview => {
-  const transactions =
-    b.transactions_aggregate &&
-    b.transactions_aggregate.aggregate &&
-    b.transactions_aggregate.aggregate.count
-      ? b.transactions_aggregate.aggregate.count
-      : 0;
+  const blockCreatorPrefix = b.createdBy.substring(0, 11);
+  const createdBy =
+    blockCreatorPrefix === 'SlotLeader-'
+      ? b.createdBy.substring(12, 18)
+      : b.createdBy;
   return {
     ...blockInfoTransformer(b),
     createdAt: b.createdAt,
-    createdBy: 'af2800c', // TODO: missing API data
-    epoch: b.epoch ? b.epoch.number : 0,
-    output: 11189.647356, // TODO: missing API data
-    transactions,
+    createdBy,
+    epoch: get(b, 'epoch.number', 0),
+    output: lovelacesToAda(
+      get(b, 'transactions_aggregate.aggregate.sum.totalOutput', 0)
+    ),
+    transactions: get(b, 'transactions_aggregate.aggregate.count', 0),
   };
 };
 
@@ -36,7 +39,7 @@ export const blockDetailsTransformer = (
 ): IBlockDetailed => ({
   ...blockOverviewTransformer(b),
   confirmations: 1, // TODO: Calculate confirmations using Cardano.blockHeight
-  merkleRoot: b.merkelRootHash ? b.merkelRootHash : 0,
+  merkleRoot: get(b, 'merkelRootHash', ''),
   nextBlock: '', // TODO: missing API data
-  prevBlock: b.previousBlock ? b.previousBlock.id : '',
+  prevBlock: get(b, 'previousBlock.id', ''),
 });

--- a/source/features/epochs/api/EpochOverview.graphql
+++ b/source/features/epochs/api/EpochOverview.graphql
@@ -1,5 +1,10 @@
 fragment EpochOverview on Epoch {
-  blocks_aggregate {
+  blocks_aggregate (
+    where: {
+      slotNo: {
+        _is_null: false
+      }
+    }) {
     aggregate {
       count
     }

--- a/source/features/epochs/api/transformers.ts
+++ b/source/features/epochs/api/transformers.ts
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import {
   EpochDetailsFragment,
   EpochOverviewFragment,
@@ -9,18 +10,15 @@ import { IEpochDetails, IEpochOverview } from '../types';
 export const epochOverviewTransformer = (
   e: EpochOverviewFragment
 ): IEpochOverview => {
-  const {
-    blocks_aggregate: { aggregate },
-  } = e;
   return {
-    blocksCount: aggregate && aggregate.count ? aggregate.count : 0,
+    blocksCount: get(e, 'blocks_aggregate.aggregate.count', 0),
     endedAt: new Date(e.lastBlockTime), // TODO: Refactor to lastBlockAt (or change the logic here to determine if it has ended
     number: e.number,
     output: e.output,
     slotsCount: 21600, // TODO: Move this to global store, as it's determined by the blockchain configuration
     startedAt: new Date(e.startedAt),
     status: '',
-    transactionsCount: e.transactionsCount || '0',
+    transactionsCount: get(e, 'transactionsCount', '0'),
   };
 };
 
@@ -28,5 +26,7 @@ export const epochDetailsTransformer = (
   e: EpochDetailsFragment
 ): IEpochDetails => ({
   ...epochOverviewTransformer(e),
-  blocks: e.blocks ? e.blocks.filter(isNotNull).map(blockInfoTransformer) : [],
+  blocks: get(e, 'blocks', [])
+    .filter(isNotNull)
+    .map(blockInfoTransformer),
 });

--- a/source/features/epochs/api/transformers.ts
+++ b/source/features/epochs/api/transformers.ts
@@ -1,9 +1,9 @@
-import { get } from 'lodash';
 import {
   EpochDetailsFragment,
   EpochOverviewFragment,
 } from '../../../../generated/typings/graphql-schema';
 import { isNotNull } from '../../../lib/types';
+import { lovelacesToAda } from '../../../lib/unit-converters';
 import { blockInfoTransformer } from '../../blocks/api/transformers';
 import { IEpochDetails, IEpochOverview } from '../types';
 
@@ -11,14 +11,18 @@ export const epochOverviewTransformer = (
   e: EpochOverviewFragment
 ): IEpochOverview => {
   return {
-    blocksCount: get(e, 'blocks_aggregate.aggregate.count', 0),
+    blocksCount:
+      (e.blocks_aggregate &&
+        e.blocks_aggregate.aggregate &&
+        e.blocks_aggregate.aggregate.count) ||
+      0,
     endedAt: new Date(e.lastBlockTime), // TODO: Refactor to lastBlockAt (or change the logic here to determine if it has ended
     number: e.number,
-    output: e.output,
+    output: lovelacesToAda(parseInt(e.output, 10)).toString() || '',
     slotsCount: 21600, // TODO: Move this to global store, as it's determined by the blockchain configuration
     startedAt: new Date(e.startedAt),
     status: '',
-    transactionsCount: get(e, 'transactionsCount', '0'),
+    transactionsCount: e.transactionsCount || '0',
   };
 };
 
@@ -26,7 +30,6 @@ export const epochDetailsTransformer = (
   e: EpochDetailsFragment
 ): IEpochDetails => ({
   ...epochOverviewTransformer(e),
-  blocks: get(e, 'blocks', [])
-    .filter(isNotNull)
-    .map(blockInfoTransformer),
+  blocks:
+    (e.blocks && e.blocks.filter(isNotNull).map(blockInfoTransformer)) || [],
 });

--- a/source/features/epochs/api/transformers.ts
+++ b/source/features/epochs/api/transformers.ts
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import {
   EpochDetailsFragment,
   EpochOverviewFragment,
@@ -11,18 +12,14 @@ export const epochOverviewTransformer = (
   e: EpochOverviewFragment
 ): IEpochOverview => {
   return {
-    blocksCount:
-      (e.blocks_aggregate &&
-        e.blocks_aggregate.aggregate &&
-        e.blocks_aggregate.aggregate.count) ||
-      0,
+    blocksCount: get(e, 'blocks_aggregate.aggregate.count', 0),
     endedAt: new Date(e.lastBlockTime), // TODO: Refactor to lastBlockAt (or change the logic here to determine if it has ended
     number: e.number,
     output: lovelacesToAda(parseInt(e.output, 10)).toString() || '',
     slotsCount: 21600, // TODO: Move this to global store, as it's determined by the blockchain configuration
     startedAt: new Date(e.startedAt),
     status: '',
-    transactionsCount: e.transactionsCount || '0',
+    transactionsCount: e.transactionsCount,
   };
 };
 

--- a/source/features/epochs/specs/epochs.spec.ts
+++ b/source/features/epochs/specs/epochs.spec.ts
@@ -34,7 +34,7 @@ describe('Epochs feature', () => {
       await waitForExpect(() => {
         expect(epochs.store.latestEpochs.length).toBe(2);
         expect(epochs.store.latestEpochs[0].number).toBe(1);
-        expect(epochs.store.latestEpochs[0].blocksCount).toBe(9485);
+        expect(epochs.store.latestEpochs[0].blocksCount).toBe(9484);
         expect(epochs.store.latestEpochs[1].number).toBe(0);
       });
       expect(epochs.store.isLoadingFirstTime).toBe(false);

--- a/source/features/network-info/store.ts
+++ b/source/features/network-info/store.ts
@@ -42,7 +42,7 @@ export class NetworkInfoStore extends Store {
     // Poll for updates
     this.pollingInterval = setInterval(
       this.fetchDynamicInfo,
-      this.slotDuration / environment.REAL_TIME_FACTOR
+      this.slotDuration / (environment.REAL_TIME_FACTOR || 1.5)
     );
   }
 

--- a/source/features/search/specs/searchForEpochByNumber.spec.ts
+++ b/source/features/search/specs/searchForEpochByNumber.spec.ts
@@ -28,9 +28,9 @@ describe('Searching for an epoch', () => {
       // 3. Expect the observable search result to be provided by the store
       await waitForExpect(() => {
         const { epochSearchResult } = search.store;
-        expect(epochSearchResult && epochSearchResult.blocksCount).toBe(9485);
+        expect(epochSearchResult && epochSearchResult.blocksCount).toBe(9484);
         expect(epochSearchResult && epochSearchResult.output).toBe(
-          '17282903106017760'
+          '17282903106.01776'
         );
         expect(epochSearchResult && epochSearchResult.transactionsCount).toBe(
           '5344'

--- a/source/features/search/specs/searchForTransactionById.spec.ts
+++ b/source/features/search/specs/searchForTransactionById.spec.ts
@@ -33,7 +33,7 @@ describe('Searching for a transaction', () => {
             search.store &&
             search.store.transactionSearchResult &&
             search.store.transactionSearchResult.totalOutput
-        ).toEqual(538861000000);
+        ).toEqual(538861);
       });
     });
   });

--- a/source/features/transactions/api/transformers.ts
+++ b/source/features/transactions/api/transformers.ts
@@ -1,5 +1,6 @@
 import { get } from 'lodash';
 import { TransactionDetailsFragment } from '../../../../generated/typings/graphql-schema';
+import { lovelacesToAda } from '../../../lib/unit-converters';
 import { ITransactionDetails } from '../types';
 
 export const transactionDetailsTransformer = (
@@ -8,9 +9,9 @@ export const transactionDetailsTransformer = (
   address: '[ADDRESS]', // TODO: missing address in API
   block: get(tx, 'block.id'),
   epoch: get(tx, 'block.epoch.number'),
-  fee: parseInt(get(tx, 'fee'), 10),
+  fee: lovelacesToAda(parseInt(get(tx, 'fee'), 10)),
   id: get(tx, 'id'),
   receivedTime: get(tx, 'includedAt'),
   slot: get(tx, 'block.slotNo'),
-  totalOutput: parseInt(get(tx, 'totalOutput'), 10),
+  totalOutput: lovelacesToAda(parseInt(get(tx, 'totalOutput'), 10)),
 });

--- a/source/lib/unit-converters.ts
+++ b/source/lib/unit-converters.ts
@@ -1,0 +1,3 @@
+export function lovelacesToAda(lovelaces: number) {
+  return lovelaces / 1000000;
+}


### PR DESCRIPTION
Also some fixes:
- Includes block creator
- Scopes Epoch blocks count to exclude EBBs and the genesis, which in this context are not important.
- Lovelaces converted to Ada
- Changelog has been cleared, as the changes are only relevant post release.

**Edit:** Updates the lodash webpack plugin config to enable deep property path selection, cleaning up the mess of guards