### PR TITLE
Fix/keep latest epoch up to date

### DIFF
--- a/source/features/blocks/store.ts
+++ b/source/features/blocks/store.ts
@@ -45,7 +45,7 @@ export class BlocksStore extends Store {
     );
   }
 
-  @computed get latestBlocks(): IBlockOverview[] {
+  @computed.struct get latestBlocks(): IBlockOverview[] {
     const { result } = this.blocksApi.getBlocksInRangeQuery;
     if (result) {
       const isBlock = (b: any): b is BlockOverviewFragment => b != null;
@@ -57,19 +57,20 @@ export class BlocksStore extends Store {
   // ============ REACTIONS =============
 
   private fetchLatestBlocks = () => {
+    const { getBlocksInRangeQuery } = this.blocksApi;
+    const networkStore = this.networkInfo.store;
+    const { blockHeight } = networkStore;
     if (
-      this.blocksApi.getBlocksInRangeQuery.isExecuting ||
-      this.networkInfo.store.isFetching ||
-      !this.networkInfo.store.blockHeight ||
-      (this.latestBlocks.length > 0 &&
-        this.latestBlocks[0] &&
-        this.latestBlocks[0].number === this.networkInfo.store.blockHeight)
+      !blockHeight ||
+      getBlocksInRangeQuery.isExecuting ||
+      networkStore.isFetching ||
+      this.latestBlocks[0]?.number === blockHeight
     ) {
       return;
     }
-    const upper = this.networkInfo.store.blockHeight;
+    const upper = blockHeight;
     const lower = Math.max(0, upper - 9);
-    this.blocksApi.getBlocksInRangeQuery.execute({
+    getBlocksInRangeQuery.execute({
       lower,
       upper,
     });

--- a/source/features/epochs/index.ts
+++ b/source/features/epochs/index.ts
@@ -1,4 +1,5 @@
 import ApolloClient from 'apollo-client';
+import { IBlocksFeature } from '../blocks';
 // import Action from '../../lib/Action';
 import { INetworkInfoFeature } from '../network-info';
 import { EpochsApi } from './api';
@@ -25,6 +26,9 @@ export interface IEpochsFeature {
 /**
  * Interfaces to dependencies on other features:
  */
+export interface IBlocksFeatureDependency {
+  store: IBlocksFeature['store'];
+}
 export interface INetworkInfoFeatureDependency {
   store: INetworkInfoFeature['store'];
 }
@@ -36,6 +40,7 @@ export interface INetworkInfoFeatureDependency {
  * configured and / or displayed multiple times on the same page.
  */
 export const createEpochsFeature = (
+  blocks: IBlocksFeatureDependency,
   networkInfo: INetworkInfoFeatureDependency,
   apolloClient: ApolloClient<object>
 ): IEpochsFeature => {
@@ -43,6 +48,7 @@ export const createEpochsFeature = (
   const epochsApi = new EpochsApi(apolloClient);
   const epochsStore = new EpochsStore(
     // epochsActions,
+    blocks,
     epochsApi,
     networkInfo
   );

--- a/source/features/epochs/specs/epochs.spec.ts
+++ b/source/features/epochs/specs/epochs.spec.ts
@@ -1,5 +1,7 @@
 import waitForExpect from 'wait-for-expect';
 import { apolloClient } from '../../../lib/graphql/apolloClient';
+import { BlocksApi } from '../../blocks/api';
+import { BlocksStore } from '../../blocks/store';
 import { NetworkInfoActions } from '../../network-info';
 import { NetworkInfoApi } from '../../network-info/api';
 import { NetworkInfoStore } from '../../network-info/store';
@@ -8,14 +10,22 @@ import { createEpochsFeature, IEpochsFeature } from '../index';
 describe('Epochs feature', () => {
   let epochs: IEpochsFeature;
   let networkInfoStore: NetworkInfoStore;
+  let blocksStore: BlocksStore;
 
   beforeEach(async () => {
     networkInfoStore = new NetworkInfoStore(
       new NetworkInfoActions(),
       new NetworkInfoApi(apolloClient)
     );
+    blocksStore = new BlocksStore(new BlocksApi(apolloClient), {
+      store: networkInfoStore,
+    });
     await networkInfoStore.start();
-    epochs = createEpochsFeature({ store: networkInfoStore }, apolloClient);
+    epochs = createEpochsFeature(
+      { store: blocksStore },
+      { store: networkInfoStore },
+      apolloClient
+    );
   });
 
   afterEach(() => {

--- a/source/features/epochs/store.ts
+++ b/source/features/epochs/store.ts
@@ -1,4 +1,4 @@
-import { computed, observable } from 'mobx';
+import { computed, observable, runInAction } from 'mobx';
 import { BlockOverviewFragment } from '../../../generated/typings/graphql-schema';
 // import { createActionBindings } from '../../lib/ActionBinding';
 import Reaction, { createReactions } from '../../lib/mobx/Reaction';
@@ -9,6 +9,7 @@ import { IBlockOverview } from '../blocks/types';
 import { EpochsApi } from './api';
 import { epochOverviewTransformer } from './api/transformers';
 import {
+  IBlocksFeatureDependency,
   // EpochsActions,
   INetworkInfoFeatureDependency,
 } from './index';
@@ -16,17 +17,21 @@ import { IEpochOverview } from './types';
 
 export class EpochsStore extends Store {
   // private readonly epochsActions: EpochsActions;
+  private readonly blocks: IBlocksFeatureDependency;
   private readonly epochsApi: EpochsApi;
   private readonly networkInfo: INetworkInfoFeatureDependency;
+  @observable private lastFetchedAtBlockHeight = 0;
 
   constructor(
     // epochsActions: EpochsActions,
+    blocks: IBlocksFeatureDependency,
     epochsApi: EpochsApi,
     networkInfo: INetworkInfoFeatureDependency
   ) {
     super();
     Object.assign(this, {
       // epochsActions,
+      blocks,
       epochsApi,
       networkInfo,
     });
@@ -35,7 +40,12 @@ export class EpochsStore extends Store {
     //     [this.epochsActions.fetchLatestEpochs, this.fetchLatestEpochs],
     //   ])
     // );
-    this.registerReactions(createReactions([this.fetchLatestEpochs]));
+    this.registerReactions(
+      createReactions([
+        this.fetchLatestEpochs,
+        this.syncLatestEpochWithLatestBlockDate,
+      ])
+    );
   }
 
   @computed get isLoadingFirstTime() {
@@ -46,7 +56,7 @@ export class EpochsStore extends Store {
     );
   }
 
-  @computed get latestEpochs(): IEpochOverview[] {
+  @computed.struct get latestEpochs(): IEpochOverview[] {
     const { result } = this.epochsApi.getEpochsInRangeQuery;
     if (result) {
       return result.data.epochs.filter(isNotNull).map(epochOverviewTransformer);
@@ -55,19 +65,40 @@ export class EpochsStore extends Store {
   }
 
   private fetchLatestEpochs = () => {
+    const { getEpochsInRangeQuery } = this.epochsApi;
+    const { blockHeight, currentEpoch } = this.networkInfo.store;
     if (
+      !currentEpoch ||
+      getEpochsInRangeQuery.isExecuting ||
       this.networkInfo.store.isFetching ||
-      !this.networkInfo.store.currentEpoch ||
-      (this.latestEpochs[0] &&
-        this.latestEpochs[0].number === this.networkInfo.store.currentEpoch)
+      this.lastFetchedAtBlockHeight === blockHeight
     ) {
       return;
     }
-    const upper = this.networkInfo.store.currentEpoch;
+    const upper = currentEpoch;
     const lower = Math.max(0, upper - 4);
-    this.epochsApi.getEpochsInRangeQuery.execute({
+    getEpochsInRangeQuery.execute({
       lower,
       upper,
     });
+    runInAction(() => {
+      this.lastFetchedAtBlockHeight = blockHeight;
+    });
+  };
+
+  private syncLatestEpochWithLatestBlockDate = () => {
+    const latestBlock = this.blocks.store.latestBlocks[0];
+    const currentEpoch = this.epochsApi.getEpochsInRangeQuery?.result?.data
+      .epochs[0];
+    if (!latestBlock || !currentEpoch) {
+      return;
+    }
+    const lastBlockTime = latestBlock.createdAt;
+    const currentEpochLastBlockTime = currentEpoch.lastBlockTime;
+    if (lastBlockTime !== currentEpochLastBlockTime) {
+      runInAction(() => {
+        currentEpoch.lastBlockTime = lastBlockTime;
+      });
+    }
   };
 }

--- a/source/features/epochs/ui/EpochsFeatureProvider.tsx
+++ b/source/features/epochs/ui/EpochsFeatureProvider.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useApolloClient } from 'react-apollo-hooks';
 import { useFeature } from '../../../lib/react/hooks';
+import { useBlocksFeature } from '../../blocks/context';
 import { useNetworkInfoFeature } from '../../network-info/context';
 import { epochsContext } from '../context';
 import { createEpochsFeature, IEpochsFeature } from '../index';
@@ -12,8 +13,9 @@ interface IProps {
 export const EpochsFeatureProvider = (props: IProps) => {
   const apolloClient = useApolloClient();
   const networkInfo = useNetworkInfoFeature();
+  const blocks = useBlocksFeature();
   const [epochsFeature] = useState<IEpochsFeature>(
-    createEpochsFeature(networkInfo, apolloClient)
+    createEpochsFeature(blocks, networkInfo, apolloClient)
   );
   useFeature(epochsFeature);
   return (

--- a/source/lib/mobx/Reaction.ts
+++ b/source/lib/mobx/Reaction.ts
@@ -26,5 +26,5 @@ export default class Reaction {
   }
 }
 
-export const createReactions = (reactions: [() => void]) =>
+export const createReactions = (reactions: Array<() => void>) =>
   reactions.map(r => new Reaction(r));

--- a/source/pages/index.tsx
+++ b/source/pages/index.tsx
@@ -36,16 +36,16 @@ if (environment.IS_CLIENT) {
         <div>
           <SearchBar brandType={BrandType.ENLARGED} />
         </div>
-        <div className={styles.epochList}>
-          <EpochsFeatureProvider>
-            <LatestEpochs />
-          </EpochsFeatureProvider>
-        </div>
-        <div className={styles.blockList}>
-          <BlocksFeatureProvider>
+        <BlocksFeatureProvider>
+          <div className={styles.epochList}>
+            <EpochsFeatureProvider>
+              <LatestEpochs />
+            </EpochsFeatureProvider>
+          </div>
+          <div className={styles.blockList}>
             <LatestBlocks />
-          </BlocksFeatureProvider>
-        </div>
+          </div>
+        </BlocksFeatureProvider>
         <Footer />
       </Layout>
       {!isMobileScreen() && (

--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,24 +1,6 @@
 module.exports = function (wallaby) {
   require('dotenv').config();
   return {
-    files: [
-      'tsconfig.json',
-      'source/**/*.ts',
-      'source/**/*.graphql',
-      '!source/**/*.spec.ts'
-    ],
-    tests: [
-      'source/**/*.spec.ts'
-    ],
-    env: {
-      type: 'node',
-    },
-    testFramework: 'jest',
-    debug: true,
-    compilers: {
-      '**/*.ts?(x)': wallaby.compilers.typeScript({
-        module: 'commonjs'
-      })
-    },
+    autoDetect: true,
   }
 };


### PR DESCRIPTION
Fixes #86 

The problem was that the latest epochs only have
been updated when a new epoch was available which
is not „realtime“ since the latest block date,
transactions and output are potentially changing
with each produced block.

The solution was to re-fetch the latest epochs
(a possible future optimization could be to only
re-fetch the current epoch) whenever the network
block height changes.

Additionally (because the data from the epochs / 
blocks endpoint are not 100% aligned) a reaction 
was added that overrides the lastBlockTime of the 
current epoch with the data from the latest 
fetched block, so that the obvious info is kept 
in sync in the UI.