### PR TITLE
Fix/summary-page-data-navigation

### DIFF
--- a/source/features/blocks/api/transformers.ts
+++ b/source/features/blocks/api/transformers.ts
@@ -40,5 +40,8 @@ export const blockDetailsTransformer = (
   confirmations: 1, // TODO: Calculate confirmations using Cardano.blockHeight
   merkleRoot: b.merkelRootHash || '',
   nextBlock: '', // TODO: missing API data
-  prevBlock: b.previousBlock?.id || '',
+  prevBlock: {
+    id: b.previousBlock?.id || '',
+    number: b.previousBlock?.number || null,
+  },
 });

--- a/source/features/blocks/api/transformers.ts
+++ b/source/features/blocks/api/transformers.ts
@@ -37,7 +37,6 @@ export const blockDetailsTransformer = (
   b: BlockDetailsFragment
 ): IBlockDetailed => ({
   ...blockOverviewTransformer(b),
-  confirmations: 1, // TODO: Calculate confirmations using Cardano.blockHeight
   merkleRoot: b.merkelRootHash || '',
   nextBlock: '', // TODO: missing API data
   prevBlock: {

--- a/source/features/blocks/types.ts
+++ b/source/features/blocks/types.ts
@@ -17,5 +17,8 @@ export interface IBlockDetailed extends IBlockOverview {
   confirmations: number;
   merkleRoot: string;
   nextBlock: string;
-  prevBlock: number;
+  prevBlock: {
+    id: IBlockInfo['id'];
+    number: IBlockInfo['number'];
+  };
 }

--- a/source/features/blocks/types.ts
+++ b/source/features/blocks/types.ts
@@ -1,3 +1,5 @@
+import { IEpochOverview } from '../epochs/types';
+
 export interface IBlockInfo {
   id: string;
   number: number | null;
@@ -8,13 +10,12 @@ export interface IBlockInfo {
 export interface IBlockOverview extends IBlockInfo {
   createdAt: Date;
   createdBy: string;
-  epoch: number;
+  epoch: IEpochOverview['number'];
   output: number;
   transactions: number;
 }
 
 export interface IBlockDetailed extends IBlockOverview {
-  confirmations: number;
   merkleRoot: string;
   nextBlock: string;
   prevBlock: {

--- a/source/features/blocks/ui/BlockSummary.tsx
+++ b/source/features/blocks/ui/BlockSummary.tsx
@@ -74,7 +74,7 @@ const BlockSummary = (props: BlockSummaryProps) => {
             <div className={styles.infoLabel}>Previous block</div>
             <div className={styles.infoValue}>
               <span onClick={onBlockIdClick(props.prevBlock.id)}>
-                {props.prevBlock.number}
+                {props.prevBlock.number ?? props.prevBlock.id}
               </span>
             </div>
           </div>

--- a/source/features/blocks/ui/BlockSummary.tsx
+++ b/source/features/blocks/ui/BlockSummary.tsx
@@ -23,6 +23,10 @@ const BlockSummary = (props: BlockSummaryProps) => {
       props.navigation?.goToBlockDetailsPage.trigger({ id });
     }
   };
+  const confirmations =
+    props.number && props.networkBlockHeight
+      ? props.networkBlockHeight - props.number + 1
+      : 0;
   return (
     <div className={styles.blockSummaryContainer}>
       <div className={styles.header}>
@@ -48,9 +52,7 @@ const BlockSummary = (props: BlockSummaryProps) => {
           </div>
           <div className={styles.infoRow}>
             <div className={styles.infoLabel}>Confirmations</div>
-            <div className={styles.infoValue}>
-              {props?.number ? props.networkBlockHeight - props?.number + 1 : 0}
-            </div>
+            <div className={styles.infoValue}>{confirmations}</div>
           </div>
           <div className={styles.infoRow}>
             <div className={styles.infoLabel}>Size</div>

--- a/source/features/blocks/ui/BlockSummary.tsx
+++ b/source/features/blocks/ui/BlockSummary.tsx
@@ -1,6 +1,7 @@
 import { observer } from 'mobx-react-lite';
 import moment from 'moment';
 import DividerWithTitle from '../../../widgets/divider-with-title/DividerWithTitle';
+import { useNavigationFeatureOptionally } from '../../navigation';
 import { IBlockDetailed } from '../types';
 import styles from './BlockSummary.scss';
 
@@ -8,68 +9,85 @@ export type BlockSummaryProps = {
   title: string;
 } & IBlockDetailed;
 
-const BlockSummary = (props: BlockSummaryProps) => (
-  <div className={styles.blockSummaryContainer}>
-    <div className={styles.header}>
-      <DividerWithTitle title={props.title} />
-    </div>
-    <div className={styles.content}>
-      <div className={styles.infoPanel}>
-        <div className={styles.infoRow}>
-          <div className={styles.infoLabel}>ID</div>
-          <div className={styles.infoValue}>{props.id}</div>
-        </div>
-        <div className={styles.infoRow}>
-          <div className={styles.infoLabel}>Epoch</div>
-          <div className={styles.infoValue}>
-            <span>{props.epoch}</span>
+const BlockSummary = (props: BlockSummaryProps) => {
+  const navigation = useNavigationFeatureOptionally();
+  return (
+    <div className={styles.blockSummaryContainer}>
+      <div className={styles.header}>
+        <DividerWithTitle title={props.title} />
+      </div>
+      <div className={styles.content}>
+        <div className={styles.infoPanel}>
+          <div className={styles.infoRow}>
+            <div className={styles.infoLabel}>ID</div>
+            <div className={styles.infoValue}>{props.id}</div>
           </div>
-        </div>
-        <div className={styles.infoRow}>
-          <div className={styles.infoLabel}>Block</div>
-          <div className={styles.infoValue}>{props.number}</div>
-        </div>
-        <div className={styles.infoRow}>
-          <div className={styles.infoLabel}>Confirmations</div>
-          <div className={styles.infoValue}>{props.confirmations}</div>
-        </div>
-        <div className={styles.infoRow}>
-          <div className={styles.infoLabel}>Size</div>
-          <div className={styles.infoValue}>{props.size} bytes</div>
-        </div>
-        <div className={styles.infoRow}>
-          <div className={styles.infoLabel}>Transactions</div>
-          <div className={styles.infoValue}>{props.transactions}</div>
-        </div>
-        <div className={styles.infoRow}>
-          <div className={styles.infoLabel}>Created by</div>
-          <div className={styles.infoValue}>{props.createdBy}</div>
-        </div>
-        <div className={styles.infoRow}>
-          <div className={styles.infoLabel}>Time</div>
-          <div className={styles.infoValue}>
-            {moment(props.createdAt).format('YYYY/MM/DD HH:mm:ss')}
+          <div
+            className={styles.infoRow}
+            onClick={() =>
+              navigation?.actions.goToEpochDetailsPage.trigger({
+                number: props.epoch,
+              })
+            }
+          >
+            <div className={styles.infoLabel}>Epoch</div>
+            <div className={styles.infoValue}>
+              <span>{props.epoch}</span>
+            </div>
           </div>
-        </div>
-        <div className={styles.infoRow}>
-          <div className={styles.infoLabel}>Previous block</div>
-          <div className={styles.infoValue}>
-            <span>{props.prevBlock}</span>
+          <div className={styles.infoRow}>
+            <div className={styles.infoLabel}>Block</div>
+            <div className={styles.infoValue}>{props.number}</div>
           </div>
-        </div>
-        <div className={styles.infoRow}>
-          <div className={styles.infoLabel}>Next block</div>
-          <div className={styles.infoValue}>
-            <span>{props.nextBlock}</span>
+          <div className={styles.infoRow}>
+            <div className={styles.infoLabel}>Confirmations</div>
+            <div className={styles.infoValue}>{props.confirmations}</div>
           </div>
-        </div>
-        <div className={styles.infoRow}>
-          <div className={styles.infoLabel}>Merkle root</div>
-          <div className={styles.infoValue}>{props.merkleRoot}</div>
+          <div className={styles.infoRow}>
+            <div className={styles.infoLabel}>Size</div>
+            <div className={styles.infoValue}>{props.size} bytes</div>
+          </div>
+          <div className={styles.infoRow}>
+            <div className={styles.infoLabel}>Transactions</div>
+            <div className={styles.infoValue}>{props.transactions}</div>
+          </div>
+          <div className={styles.infoRow}>
+            <div className={styles.infoLabel}>Created by</div>
+            <div className={styles.infoValue}>{props.createdBy}</div>
+          </div>
+          <div className={styles.infoRow}>
+            <div className={styles.infoLabel}>Time</div>
+            <div className={styles.infoValue}>
+              {moment(props.createdAt).format('YYYY/MM/DD HH:mm:ss')}
+            </div>
+          </div>
+          <div
+            className={styles.infoRow}
+            onClick={() =>
+              navigation?.actions.goToBlockDetailsPage.trigger({
+                id: props.prevBlock.id,
+              })
+            }
+          >
+            <div className={styles.infoLabel}>Previous block</div>
+            <div className={styles.infoValue}>
+              <span>{props.prevBlock.number}</span>
+            </div>
+          </div>
+          <div className={styles.infoRow}>
+            <div className={styles.infoLabel}>Next block</div>
+            <div className={styles.infoValue}>
+              <span>{props.nextBlock}</span>
+            </div>
+          </div>
+          <div className={styles.infoRow}>
+            <div className={styles.infoLabel}>Merkle root</div>
+            <div className={styles.infoValue}>{props.merkleRoot}</div>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default observer(BlockSummary);

--- a/source/features/blocks/ui/BlockSummary.tsx
+++ b/source/features/blocks/ui/BlockSummary.tsx
@@ -1,16 +1,28 @@
 import { observer } from 'mobx-react-lite';
 import moment from 'moment';
 import DividerWithTitle from '../../../widgets/divider-with-title/DividerWithTitle';
-import { useNavigationFeatureOptionally } from '../../navigation';
+import { NavigationActions } from '../../navigation';
+import { ITransactionDetails } from '../../transactions/types';
 import { IBlockDetailed } from '../types';
 import styles from './BlockSummary.scss';
 
 export type BlockSummaryProps = {
+  navigation?: NavigationActions;
+  networkBlockHeight: number;
   title: string;
 } & IBlockDetailed;
 
 const BlockSummary = (props: BlockSummaryProps) => {
-  const navigation = useNavigationFeatureOptionally();
+  const onEpochNumberClick = (epoch: ITransactionDetails['epoch']) => () => {
+    if (epoch) {
+      props.navigation?.goToEpochDetailsPage.trigger({ number: epoch });
+    }
+  };
+  const onBlockIdClick = (id: ITransactionDetails['block']['id']) => () => {
+    if (id) {
+      props.navigation?.goToBlockDetailsPage.trigger({ id });
+    }
+  };
   return (
     <div className={styles.blockSummaryContainer}>
       <div className={styles.header}>
@@ -22,17 +34,12 @@ const BlockSummary = (props: BlockSummaryProps) => {
             <div className={styles.infoLabel}>ID</div>
             <div className={styles.infoValue}>{props.id}</div>
           </div>
-          <div
-            className={styles.infoRow}
-            onClick={() =>
-              navigation?.actions.goToEpochDetailsPage.trigger({
-                number: props.epoch,
-              })
-            }
-          >
+          <div className={styles.infoRow}>
             <div className={styles.infoLabel}>Epoch</div>
             <div className={styles.infoValue}>
-              <span>{props.epoch}</span>
+              <span onClick={onEpochNumberClick(props.epoch)}>
+                {props.epoch}
+              </span>
             </div>
           </div>
           <div className={styles.infoRow}>
@@ -41,7 +48,9 @@ const BlockSummary = (props: BlockSummaryProps) => {
           </div>
           <div className={styles.infoRow}>
             <div className={styles.infoLabel}>Confirmations</div>
-            <div className={styles.infoValue}>{props.confirmations}</div>
+            <div className={styles.infoValue}>
+              {props?.number ? props.networkBlockHeight - props?.number + 1 : 0}
+            </div>
           </div>
           <div className={styles.infoRow}>
             <div className={styles.infoLabel}>Size</div>
@@ -61,17 +70,12 @@ const BlockSummary = (props: BlockSummaryProps) => {
               {moment(props.createdAt).format('YYYY/MM/DD HH:mm:ss')}
             </div>
           </div>
-          <div
-            className={styles.infoRow}
-            onClick={() =>
-              navigation?.actions.goToBlockDetailsPage.trigger({
-                id: props.prevBlock.id,
-              })
-            }
-          >
+          <div className={styles.infoRow}>
             <div className={styles.infoLabel}>Previous block</div>
             <div className={styles.infoValue}>
-              <span>{props.prevBlock.number}</span>
+              <span onClick={onBlockIdClick(props.prevBlock.id)}>
+                {props.prevBlock.number}
+              </span>
             </div>
           </div>
           <div className={styles.infoRow}>

--- a/source/features/epochs/ui/EpochList.tsx
+++ b/source/features/epochs/ui/EpochList.tsx
@@ -5,7 +5,6 @@ import CircularProgress, {
   CircularProgressSize,
 } from '../../../widgets/circular-progress/CircularProgress';
 import Table, { IColumnDefinition } from '../../../widgets/table/Table';
-import { IBlockListRowProps } from '../../blocks/ui/BlockList';
 import { useNavigationFeatureOptionally } from '../../navigation';
 import styles from './EpochList.scss';
 

--- a/source/features/search/specs/searchForBlockByNumber.spec.ts
+++ b/source/features/search/specs/searchForBlockByNumber.spec.ts
@@ -37,7 +37,7 @@ describe('Searching for a block', () => {
 
       // 3. Access the observable search result provided by the store
       await waitForExpect(() => {
-        expect(search.store?.blockSearchResult?.prevBlock).toBe(
+        expect(search.store?.blockSearchResult?.prevBlock.id).toBe(
           '687bc1d9ff5b7c8167b25cca5659e80a40583512ba925271bf3005600eb0a0ec'
         );
         expect(search.store?.blockSearchResult?.transactions).toBe(0);

--- a/source/features/search/ui/BlockSearchResult.tsx
+++ b/source/features/search/ui/BlockSearchResult.tsx
@@ -3,11 +3,13 @@ import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
 import LoadingSpinner from '../../../widgets/loading-spinner/LoadingSpinner';
 import BlockSummary from '../../blocks/ui/BlockSummary';
+import { useNavigationFeature } from '../../navigation';
 import { useSearchFeature } from '../context';
 import NoSearchResult from './NoSearchResult';
 
 export const BlockSearchResult = () => {
   const { actions, store } = useSearchFeature();
+  const navigation = useNavigationFeature();
   const router = useRouter();
 
   // Trigger search after component did render

--- a/source/features/search/ui/BlockSearchResult.tsx
+++ b/source/features/search/ui/BlockSearchResult.tsx
@@ -3,13 +3,15 @@ import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
 import LoadingSpinner from '../../../widgets/loading-spinner/LoadingSpinner';
 import BlockSummary from '../../blocks/ui/BlockSummary';
-import { useNavigationFeature } from '../../navigation';
+import { useNavigationFeatureOptionally } from '../../navigation';
+import { useNetworkInfoFeature } from '../../network-info/context';
 import { useSearchFeature } from '../context';
 import NoSearchResult from './NoSearchResult';
 
 export const BlockSearchResult = () => {
   const { actions, store } = useSearchFeature();
-  const navigation = useNavigationFeature();
+  const networkInfo = useNetworkInfoFeature();
+  const navigation = useNavigationFeatureOptionally();
   const router = useRouter();
 
   // Trigger search after component did render
@@ -27,7 +29,14 @@ export const BlockSearchResult = () => {
         if (store.isSearching) {
           return <LoadingSpinner />;
         } else if (blockSearchResult) {
-          return <BlockSummary title="Block Summary" {...blockSearchResult} />;
+          return (
+            <BlockSummary
+              navigation={navigation?.actions}
+              networkBlockHeight={networkInfo.store.blockHeight}
+              title="Block Summary"
+              {...blockSearchResult}
+            />
+          );
         } else {
           return <NoSearchResult />;
         }

--- a/source/features/transactions/api/transformers.ts
+++ b/source/features/transactions/api/transformers.ts
@@ -7,8 +7,8 @@ export const transactionDetailsTransformer = (
 ): ITransactionDetails => ({
   address: '[ADDRESS]', // TODO: missing address in API
   block: {
-    height: tx.block?.number,
     id: tx.block?.id,
+    number: tx.block?.number,
   },
   epoch: tx.block?.epoch?.number,
   fee: lovelacesStringToAdaNumber(tx.fee),

--- a/source/features/transactions/components/TransactionSummary.tsx
+++ b/source/features/transactions/components/TransactionSummary.tsx
@@ -42,7 +42,7 @@ const TransactionSummary = ({
           <div className={styles.infoRow}>
             <div className={styles.infoLabel}>Confirmations</div>
             <div className={styles.infoValue}>
-              {txBlock?.height ? networkBlockHeight - txBlock?.height + 1 : 0}
+              {txBlock?.number ? networkBlockHeight - txBlock?.number + 1 : 0}
             </div>
           </div>
           <div className={styles.infoRow}>
@@ -58,7 +58,7 @@ const TransactionSummary = ({
               )}
               , Slot {transaction.slot}, block{' '}
               <span onClick={onBlockIdClick(transaction.block.id)}>
-                {transaction.block.height ?? transaction.block.id}
+                {transaction.block.number ?? transaction.block.id}
               </span>
             </div>
           </div>

--- a/source/features/transactions/types.ts
+++ b/source/features/transactions/types.ts
@@ -1,8 +1,10 @@
+import { IBlockDetailed } from '../blocks/types';
+
 export interface ITransactionDetails {
   address: string;
   block: {
-    id?: string;
-    height?: number | null;
+    id?: IBlockDetailed['id'];
+    number?: IBlockDetailed['number'];
   };
   epoch?: number;
   id: string;

--- a/stories/blocks.stories.tsx
+++ b/stories/blocks.stories.tsx
@@ -74,7 +74,10 @@ const blockSummary = {
   nextBlock: '2111edea30970af11172bd8e2f05c7406cba8f20d9bb78c4fa62ba06881372e7',
   number: 11044,
   output: 13130,
-  prevBlock: 11043,
+  prevBlock: {
+    id: '8b09535f8b6109cbdd6ab4d036ec0a43426be2e4d799c46652f291fa6fa9987f',
+    number: 11043,
+  },
   size: 634,
   slotWithinEpoch: 11043,
   time: 1470006392000,
@@ -144,7 +147,9 @@ storiesOf('Blocks', module)
   .add('Block List', () => (
     <BlockList title="Blocks" items={blocks} isLoading={false} />
   ))
-  .add('Block Summary', () => <BlockSummary {...blockSummary} />)
+  .add('Block Summary', () => (
+    <BlockSummary networkBlockHeight={11044 + 100} {...blockSummary} />
+  ))
   .add('Block Creation', () => (
     <BlockCreation title="Block Creation" items={blockCreation} />
   ));

--- a/stories/transactions.stories.tsx
+++ b/stories/transactions.stories.tsx
@@ -9,8 +9,8 @@ const transactionSummary = {
   address:
     'DdzFFzCqrhshP3eXMp6T6yBAurVd1cJsD8WHg7BbBwNy3AVN2k5jqDPENM9U4zHX5mqdZWxbELWtQnc8dzsM9f8k1dEiuMW9aDU1AGes',
   block: {
-    height: 11044,
     id: '5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb',
+    number: 11044,
   },
   epoch: 48,
   fee: 0.171246,


### PR DESCRIPTION
Adds navigation to the block summary page, including previous block and epoch, and implements block confirmation logic.

