### PR TITLE
Fixes #123 - improve browsing params handling

### DIFF
--- a/source/features/blocks/ui/BlocksBrowser.tsx
+++ b/source/features/blocks/ui/BlocksBrowser.tsx
@@ -13,9 +13,9 @@ import { useNetworkInfoFeature } from '../../network-info/context';
 import { useBlocksFeature } from '../context';
 import BlockList from './BlockList';
 
-const BLOCKS_PER_PAGE_DEFAULT = 10;
+const BLOCKS_PER_PAGE_DEFAULT = 20;
 const BLOCKS_PER_PAGE_MINIMUM = 5;
-const BLOCKS_PER_PAGE_MAXIMUM = 30;
+const BLOCKS_PER_PAGE_MAXIMUM = 50;
 
 const createBrowsePath = ({ lower, upper }: IBrowseInRangeBounds) =>
   `/browse-blocks?lower=${lower}&upper=${upper}`;
@@ -43,9 +43,6 @@ const BlocksBrowser = () => {
             onReadyToBrowse={params => {
               blocks.actions.browseBlocks.trigger(params.bounds);
               setBrowserParams(params);
-            }}
-            onQueryParamsUpdateRequired={bounds => {
-              router.push(createBrowsePath(bounds));
             }}
             perPageDefault={BLOCKS_PER_PAGE_DEFAULT}
             perPageMinimum={BLOCKS_PER_PAGE_MINIMUM}

--- a/source/features/blocks/ui/BlocksBrowser.tsx
+++ b/source/features/blocks/ui/BlocksBrowser.tsx
@@ -13,6 +13,8 @@ import { useNetworkInfoFeature } from '../../network-info/context';
 import { useBlocksFeature } from '../context';
 import BlockList from './BlockList';
 
+// TODO: This actually fetches 1 item more than given
+// because the query includes lower and upper boundaries
 const BLOCKS_PER_PAGE_DEFAULT = 20;
 const BLOCKS_PER_PAGE_MINIMUM = 5;
 const BLOCKS_PER_PAGE_MAXIMUM = 50;

--- a/source/features/blocks/ui/LatestBlocks.tsx
+++ b/source/features/blocks/ui/LatestBlocks.tsx
@@ -28,13 +28,7 @@ export const LatestBlocks = () => {
               store.isLoadingLatestBlocksFirstTime ||
               store.latestBlocks.length < 10
             }
-            onClick={() =>
-              router.push(
-                `/browse-blocks?lower=${
-                  latestBlocks[latestBlocks.length - 1].number
-                }&upper=${latestBlocks[0].number}`
-              )
-            }
+            onClick={() => router.push('/browse-blocks')}
           >
             <BlockList
               isLoading={store.isLoadingLatestBlocksFirstTime}

--- a/source/features/epochs/ui/EpochsBrowser.tsx
+++ b/source/features/epochs/ui/EpochsBrowser.tsx
@@ -13,9 +13,9 @@ import { useNetworkInfoFeature } from '../../network-info/context';
 import { useEpochsFeature } from '../context';
 import EpochList from './EpochList';
 
-const EPOCHS_PER_PAGE_DEFAULT = 10;
+const EPOCHS_PER_PAGE_DEFAULT = 20;
 const EPOCHS_PER_PAGE_MINIMUM = 5;
-const EPOCHS_PER_PAGE_MAXIMUM = 30;
+const EPOCHS_PER_PAGE_MAXIMUM = 50;
 
 const createBrowsePath = ({ lower, upper }: IBrowseInRangeBounds) =>
   `/browse-epochs?lower=${lower}&upper=${upper}`;
@@ -43,9 +43,6 @@ const EpochsBrowser = () => {
             onReadyToBrowse={params => {
               epochs.actions.browseEpochs.trigger(params.bounds);
               setBrowserParams(params);
-            }}
-            onQueryParamsUpdateRequired={bounds => {
-              router.push(createBrowsePath(bounds));
             }}
             perPageDefault={EPOCHS_PER_PAGE_DEFAULT}
             perPageMinimum={EPOCHS_PER_PAGE_MINIMUM}

--- a/source/features/epochs/ui/LatestEpochs.tsx
+++ b/source/features/epochs/ui/LatestEpochs.tsx
@@ -28,13 +28,7 @@ export const LatestEpochs = () => {
               store.isLoadingLatestEpochsFirstTime ||
               store.latestEpochs.length < 5
             }
-            onClick={() =>
-              router.push(
-                `/browse-epochs?lower=${
-                  latestEpochs[latestEpochs.length - 1].number
-                }&upper=${latestEpochs[0].number}`
-              )
-            }
+            onClick={() => router.push('/browse-epochs')}
           >
             <EpochList
               title="Latest Epochs"

--- a/source/features/search/ui/EpochsSearchResult.tsx
+++ b/source/features/search/ui/EpochsSearchResult.tsx
@@ -75,11 +75,7 @@ export const EpochsSearchResult = () => {
                 isHidden={epochSearchResult.blocks.length < 10}
                 onClick={() =>
                   router.push(
-                    `/browse-blocks?lower=${
-                      epochSearchResult.blocks[
-                        epochSearchResult.blocks.length - 1
-                      ].number
-                    }&upper=${epochSearchResult.blocks[0].number}`
+                    `/browse-blocks?upper=${epochSearchResult.blocks[0].number}`
                   )
                 }
               >

--- a/source/widgets/browsing/BrowseInRange.tsx
+++ b/source/widgets/browsing/BrowseInRange.tsx
@@ -38,6 +38,8 @@ const calculateBrowseBounds = ({
   }
   if (upper > total) {
     upper = total;
+  } else if (upper < perPageMinimum) {
+    upper = perPageMinimum;
   }
   if (lower < 0) {
     lower = 0;
@@ -58,7 +60,6 @@ export interface IBrowseInRangeResult {
 
 export interface IBrowseInRangeProps {
   total: number;
-  onQueryParamsUpdateRequired: (bounds: IBrowseInRangeBounds) => void;
   onReadyToBrowse: (browseParams: IBrowseInRangeResult) => void;
   perPageDefault: number;
   perPageMinimum: number;
@@ -69,7 +70,6 @@ export interface IBrowseInRangeProps {
 
 export const BrowseInRange = ({
   onReadyToBrowse,
-  onQueryParamsUpdateRequired,
   perPageDefault,
   perPageMinimum,
   perPageMaximum,
@@ -93,12 +93,8 @@ export const BrowseInRange = ({
     bounds.upper.toString() === userParamUpper;
 
   useEffect(() => {
-    if (!isCorrectPath) {
-      onQueryParamsUpdateRequired(bounds);
-    } else {
-      // If params are correct, trigger search
-      onReadyToBrowse({ bounds, currentPage, itemsPerPage, totalPages });
-    }
+    // If params are correct, trigger search
+    onReadyToBrowse({ bounds, currentPage, itemsPerPage, totalPages });
   }, [userParamLower, userParamUpper]);
 
   return null; // Renderless component

--- a/source/widgets/browsing/BrowseInRange.tsx
+++ b/source/widgets/browsing/BrowseInRange.tsx
@@ -88,9 +88,6 @@ export const BrowseInRange = ({
   const itemsPerPage = bounds.upper - bounds.lower;
   const totalPages = Math.floor(total / itemsPerPage);
   const currentPage = Math.floor(bounds.upper / itemsPerPage);
-  const isCorrectPath =
-    bounds.lower.toString() === userParamLower &&
-    bounds.upper.toString() === userParamUpper;
 
   useEffect(() => {
     // If params are correct, trigger search


### PR DESCRIPTION
This PR fixes a couple of issues with the browsing implementation:

- Handle invalid `upper` params correctly
- No redirect on invalid / incomplete params (just interpret best as possible), results in proper browser navigation support.
- Changes the default number of epochs and blocks to 20 and increase max to 50.