### PR TITLE
Fix/blocks list perf and next block

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
 version: '3.7'
 services:
   api:
-    image: samjeston/cardano-graphql-dev:0.3.0
+    image: samjeston/cardano-graphql-dev:0.4.0
     restart: always
     environment:
       - HASURA_URI=http://hasura:8080/v1/graphql
     ports:
       - ${API_PORT:-3100}:3100
   hasura:
-    image: samjeston/cardano-graphql-hasura:0.3.0
+    image: samjeston/cardano-graphql-hasura:0.4.0
     depends_on:
       - "postgres"
     restart: always
@@ -17,5 +17,5 @@ services:
       - HASURA_GRAPHQL_ENABLE_CONSOLE=false
       - HASURA_GRAPHQL_ENABLED_LOG_TYPES=startup
   postgres:
-    image: samjeston/cardano-graphql-pgseed:0.3.0
+    image: samjeston/cardano-graphql-pgseed:0.4.0
     restart: always

--- a/source/features/blocks/api/BlockDetails.graphql
+++ b/source/features/blocks/api/BlockDetails.graphql
@@ -4,6 +4,10 @@
 fragment BlockDetails on Block {
   ...BlockOverview
   merkelRootHash
+  nextBlock {
+    id
+    number
+  }
   previousBlock {
     id
     number

--- a/source/features/blocks/api/BlockOverview.graphql
+++ b/source/features/blocks/api/BlockOverview.graphql
@@ -1,9 +1,7 @@
 fragment BlockOverview on Block {
   createdAt
   createdBy
-  epoch {
-    number
-  },
+  epochNo,
   id
   number
   size

--- a/source/features/blocks/api/transformers.ts
+++ b/source/features/blocks/api/transformers.ts
@@ -18,7 +18,7 @@ export const blockOverviewTransformer = (
   return {
     createdAt: b.createdAt,
     createdBy,
-    epoch: b.epoch?.number || 0,
+    epoch: b.epochNo,
     id: b.id,
     number: b.number || 0,
     output: lovelacesToAda(

--- a/source/features/blocks/api/transformers.ts
+++ b/source/features/blocks/api/transformers.ts
@@ -35,7 +35,10 @@ export const blockDetailsTransformer = (
 ): IBlockDetailed => ({
   ...blockOverviewTransformer(b),
   merkleRoot: b.merkelRootHash || '',
-  nextBlock: '', // TODO: missing API data
+  nextBlock: {
+    id: b.nextBlock?.id || '',
+    number: b.nextBlock?.number || null,
+  },
   prevBlock: {
     id: b.previousBlock?.id || '',
     number: b.previousBlock?.number || null,

--- a/source/features/blocks/types.ts
+++ b/source/features/blocks/types.ts
@@ -15,7 +15,10 @@ export interface IBlockOverview {
 
 export interface IBlockDetailed extends IBlockOverview {
   merkleRoot: string;
-  nextBlock: string;
+  nextBlock: {
+    id: IBlockOverview['id'];
+    number: IBlockOverview['number'];
+  };
   prevBlock: {
     id: IBlockOverview['id'];
     number: IBlockOverview['number'];

--- a/source/features/blocks/ui/BlockSummary.tsx
+++ b/source/features/blocks/ui/BlockSummary.tsx
@@ -85,7 +85,9 @@ const BlockSummary = (props: BlockSummaryProps) => {
           <div className={styles.infoRow}>
             <div className={styles.infoLabel}>Next block</div>
             <div className={styles.infoValue}>
-              <span>{props.nextBlock}</span>
+              <span onClick={onBlockIdClick(props.nextBlock.id)}>
+                {props.nextBlock.number ?? props.nextBlock.id}
+              </span>
             </div>
           </div>
           <div className={styles.infoRow}>


### PR DESCRIPTION
This PR updates the Cardano GraphQL dependency to `0.4.0`, Closes #115 , and fixes the performance issue identified in https://github.com/input-output-hk/cardano-graphql/issues/91

**N.B**
The staging version of Cardano GraphQL needs to be updated before `nextBlock` will work. The local dataset must be used to see this working.