### PR TITLE
chore/cardano-js 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "apollo-link-http": "1.5.15",
     "array-sync": "4.0.0",
     "browser-update": "3.3.1",
-    "cardano-js": "0.2.2",
+    "cardano-js": "0.3.0",
     "chroma-js": "2.0.6",
     "classnames": "2.2.6",
     "color": "3.1.2",

--- a/source/features/address/api/transformers.ts
+++ b/source/features/address/api/transformers.ts
@@ -1,4 +1,4 @@
-import { lovelacesToAda } from 'cardano-js/dist/Currency';
+import { Currency } from 'cardano-js';
 import { SearchForAddressQuery } from '../../../../generated/typings/graphql-schema';
 import { isNotNull } from '../../../lib/types';
 import { transactionDetailsTransformer } from '../../transactions/api/transformers';
@@ -9,7 +9,9 @@ export const addressDetailTransformer = (
   s: SearchForAddressQuery
 ): IAddressDetail => ({
   address,
-  finalBalance: lovelacesToAda(s.utxos_aggregate?.aggregate?.sum?.value || '0'),
+  finalBalance: Currency.Util.lovelacesToAda(
+    s.utxos_aggregate?.aggregate?.sum?.value || '0'
+  ),
   transactions: s.transactions
     .filter(isNotNull)
     .map(transactionDetailsTransformer),

--- a/source/features/search/ui/SearchBar.tsx
+++ b/source/features/search/ui/SearchBar.tsx
@@ -1,7 +1,8 @@
-import { Util } from 'cardano-js';
+import { Address } from 'cardano-js';
+import { AddressGroup } from 'cardano-js/dist/Address/AddressGroup';
 import { ChainSettings } from 'cardano-js/dist/ChainSettings';
 import React from 'react';
-import { BrandType, CardanoNetwork } from '../../../constants';
+import { BrandType, CardanoEra, CardanoNetwork } from '../../../constants';
 import { environment } from '../../../environment';
 import { useNetworkInfoFeature } from '../../network-info/context';
 import { useSearchFeature } from '../context';
@@ -19,7 +20,13 @@ export const SearchBar = (props: ISearchBarProps) => {
       environment.CARDANO.NETWORK === CardanoNetwork.MAINNET
         ? ChainSettings.mainnet
         : ChainSettings.testnet;
-    if (Util.isAddress(query, chainSettings)) {
+    // Assuming the AddressGroup.jormungandr is the format for Shelley addresses
+    // Will update when final decision is made.
+    const addressGroup =
+      environment.CARDANO.ERA === CardanoEra.BYRON
+        ? AddressGroup.byron
+        : AddressGroup.jormungandr;
+    if (Address.Util.isAddress(query, chainSettings, addressGroup)) {
       search.actions.addressSearchRequested.trigger({
         address: query,
       });

--- a/source/features/transactions/api/transformers.ts
+++ b/source/features/transactions/api/transformers.ts
@@ -1,4 +1,4 @@
-import { lovelacesToAda } from 'cardano-js/dist/Currency';
+import { Currency } from 'cardano-js';
 import { TransactionDetailsFragment } from '../../../../generated/typings/graphql-schema';
 import { ITransactionDetails } from '../types';
 
@@ -10,16 +10,16 @@ export const transactionDetailsTransformer = (
     id: tx.block?.id,
     number: tx.block?.number,
   },
-  fee: lovelacesToAda(tx.fee),
+  fee: Currency.Util.lovelacesToAda(tx.fee),
   id: tx.id,
   includedAt: new Date(tx.includedAt),
   inputs: tx.inputs.map(i => ({
     ...i,
-    value: lovelacesToAda(i.value),
+    value: Currency.Util.lovelacesToAda(i.value),
   })),
   outputs: tx.outputs.map(i => ({
     ...i,
-    value: lovelacesToAda(i.value),
+    value: Currency.Util.lovelacesToAda(i.value),
   })),
-  totalOutput: lovelacesToAda(tx.totalOutput),
+  totalOutput: Currency.Util.lovelacesToAda(tx.totalOutput),
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4497,10 +4497,10 @@ capture-stack-trace@^1.0.0:
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
   integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
 
-cardano-js@0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/cardano-js/-/cardano-js-0.2.2.tgz#1e9c0749527a68d797aa211f6daefba0354ef63f"
-  integrity sha512-xmeeHHbZk5uqdygOh03cDBJjjnXhIRtRZ65i3MESVbaGp+8K1AtizGqKK1izjD4ktMK2Tefd1utrzHgXxt9WzA==
+cardano-js@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/cardano-js/-/cardano-js-0.3.0.tgz#8e3bf5f2a018b1c48719b89ee6540aae2979438f"
+  integrity sha512-XRNZSJBZp3mSIijD/X+BTwI4DcPLia5RAtgbuHfGuurcv5B+Ny6to1FWWQSum6by5i8dTNTNkvPiFZwRsp2V+A==
   dependencies:
     bech32 "^1.1.3"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
Upgrade to cardano-js 0.3.0, adding the specificity of Cardano era to determine address format validity