### PR TITLE
Do not link to search result epoch in block list

### DIFF
--- a/source/features/blocks/ui/BlockList.scss
+++ b/source/features/blocks/ui/BlockList.scss
@@ -9,15 +9,6 @@
       width: 100px;
     }
 
-    .TableBodyRow_row {
-      .epoch {
-        color: $primary-highlight-color;
-      }
-      .blocksSlots {
-        color: $primary-highlight-color;
-      }
-    }
-
     .createdAt {
       width: 160px;
     }

--- a/source/features/blocks/ui/BlockList.tsx
+++ b/source/features/blocks/ui/BlockList.tsx
@@ -8,12 +8,14 @@ import { IBlockOverview } from '../types';
 import styles from './BlockList.scss';
 
 export interface IBlockListProps {
+  ignoreLinksToEpoch?: number;
   isLoading: boolean;
   items: Array<IBlockOverview>;
   title: string;
 }
 
 interface IColumnsProps {
+  ignoreLinksToEpoch?: number;
   onEpochNumberClicked: (epochNo: IBlockOverview['epoch']) => void;
   onBlockNumberClicked: (id: IBlockOverview['id']) => void;
 }
@@ -27,6 +29,8 @@ const columns = (
     cellValue: (row: IBlockOverview) => `${row.epoch} / ${row.slotWithinEpoch}`,
     cssClass: 'epoch',
     head: 'Epoch / Slot',
+    isCellClickable: (row: IBlockOverview) =>
+      props.ignoreLinksToEpoch !== row.epoch,
     key: 'epochsSlots',
   },
   {
@@ -77,6 +81,7 @@ const BlockList: FC<IBlockListProps> = props => {
       <Table
         title={props.title}
         columns={columns({
+          ignoreLinksToEpoch: props.ignoreLinksToEpoch,
           onBlockNumberClicked: id =>
             navigation?.actions.goToBlockDetailsPage.trigger({
               id,

--- a/source/features/search/ui/EpochsSearchResult.tsx
+++ b/source/features/search/ui/EpochsSearchResult.tsx
@@ -84,6 +84,7 @@ export const EpochsSearchResult = () => {
               >
                 <BlockList
                   title="Blocks"
+                  ignoreLinksToEpoch={epochSearchResult?.number}
                   items={epochSearchResult.blocks.slice(0, 10)}
                   isLoading={false}
                 />

--- a/source/widgets/table/Table.tsx
+++ b/source/widgets/table/Table.tsx
@@ -17,6 +17,7 @@ export interface IColumnDefinition<R = any, CE = any, CO = any> {
   cellValue?: Transform<R, CE>;
   cellOnClick?: (row: CE) => void;
   cssClass?: string;
+  isCellClickable?: (row: CE) => boolean;
   head: CellHeaderTemplate;
   key: string;
 }

--- a/source/widgets/table/TableBodyRow.scss
+++ b/source/widgets/table/TableBodyRow.scss
@@ -16,6 +16,7 @@
 }
 
 .clickableCell {
+  color: $primary-highlight-color;
   &:hover {
     cursor: pointer;
   }

--- a/source/widgets/table/TableBodyRow.tsx
+++ b/source/widgets/table/TableBodyRow.tsx
@@ -26,10 +26,11 @@ const TableBodyRow: FC<ITableBodyRowProps> = ({ columns, row }) => (
           cellContent = column.cellRender;
         }
       }
-
+      const isCellClickable =
+        !column.isCellClickable || column.isCellClickable(row);
       return (
         <div key={`column_${index}`} className={column.cssClass}>
-          {column.cellOnClick ? (
+          {isCellClickable && column.cellOnClick ? (
             <span
               className={styles.clickableCell}
               onClick={() => {


### PR DESCRIPTION
This PR removes the links to the epoch in the Block list when viewing an epoch search result:
![screenshot 2019-12-16 um 20 50 04](https://user-images.githubusercontent.com/172414/70938016-aa498a80-2045-11ea-936d-0d5f027ca064.png)
