### PR TITLE
[issue-162] Update and fix browser update setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@types/react-addons-css-transition-group": "15.0.5",
     "array-sync": "4.0.0",
-    "browser-update": "3.3.1",
+    "browser-update": "3.3.9",
     "cardano-js": "0.3.0",
     "chroma-js": "2.0.6",
     "classnames": "2.2.6",

--- a/source/features/outdated-browser/BrowserUpdate.tsx
+++ b/source/features/outdated-browser/BrowserUpdate.tsx
@@ -18,7 +18,7 @@ export const BrowserUpdate = () => {
         reminderClosed: 150,
         // if the user explicitly closes message it reappears after x hours
 
-        required: { i: 8, f: 25, o: 17, s: 9, c: 22 },
+        required: { e: -3, f: -3, o: -3, s: -1, c: -3 },
         // Specifies required browser versions
         // Browsers older than this will be notified.
         // f:22 ---> Firefox < 22 gets notified

--- a/yarn.lock
+++ b/yarn.lock
@@ -4557,10 +4557,10 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
-browser-update@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/browser-update/-/browser-update-3.3.1.tgz#140c046d38ec1d91aaf4679b585a9741bd06e47e"
-  integrity sha512-Wk8/puLUA6p2UGB6kRK1scJ4VcMyl0Ye+5XW7v6j2K3sJAQ1t9jjEFJcWjg2GNqaw3HFTcuFjIeL23NJV6gs2g==
+browser-update@3.3.9:
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/browser-update/-/browser-update-3.3.9.tgz#62a23b1002676ab3602929fd5d3d514bf1f11f9a"
+  integrity sha512-I2X8GhOJyvgSqesthJoD1tFkU1VE3ofMIZZVs+M+2pVB9tJtwulx3U0s7Ds/aH0SyW0gLSqCQ10Yli37694S7w==
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"


### PR DESCRIPTION
This PR fixes #162 by upgrading the `browser-update` package and improves the browser detection to work with negative offsets, so we don't have to maintain the latest browser versions ourself.