### PR TITLE
Fix: Dont use external urls with next.js Link

### DIFF
--- a/source/features/errors/PageNotFoundError.tsx
+++ b/source/features/errors/PageNotFoundError.tsx
@@ -38,9 +38,12 @@ export default class Error extends Component<IErrorProps> {
               <a className={styles.bottomContainerLink}>Blockchain Explorer</a>
             </Link>
             <div className={styles.bottomContainerLinksSeparator} />
-            <Link href="https://help.cardano.org/">
-              <a className={styles.bottomContainerLink}>Contact Support</a>
-            </Link>
+            <a
+              href="https://help.cardano.org/"
+              className={styles.bottomContainerLink}
+            >
+              Contact Support
+            </a>
           </div>
         </div>
       </div>

--- a/source/widgets/layout/Footer.tsx
+++ b/source/widgets/layout/Footer.tsx
@@ -24,11 +24,12 @@ export const Footer = (props: IFooterProps) => {
             <p className={styles.copyright}>
               © IOHK 2015 - {new Date().getFullYear()}
             </p>
-            <Link href="https://github.com/input-output-hk/cardano-explorer-app/">
-              <a className={styles.gitLink}>
-                <GitIcon className={styles.gitIcon} />
-              </a>
-            </Link>
+            <a
+              href="https://github.com/input-output-hk/cardano-explorer-app/"
+              className={styles.gitLink}
+            >
+              <GitIcon className={styles.gitIcon} />
+            </a>
           </div>
           <div className={styles.logos}>
             <div className={styles.logoText}>


### PR DESCRIPTION
This fixes an known limitation of the `next/Link` component that throws a warning when you use it with external URLs - the reason is that the `<Link>` component in Next.js is special as it pre-loads the contents of the linked page (which doesn't work for external pages)