### PR TITLE
[issue-193] Improve static rendering of landing page and general loading state consistency

### DIFF
--- a/source/features/blocks/ui/BlockList.module.scss
+++ b/source/features/blocks/ui/BlockList.module.scss
@@ -88,7 +88,6 @@
   position: absolute;
   width: 100%;
   height: 100%;
-  display: flex;
-  align-items: center;
+  padding-top: 40px;
   backdrop-filter: blur(1px);
 }

--- a/source/features/blocks/ui/BlocksBrowser.module.scss
+++ b/source/features/blocks/ui/BlocksBrowser.module.scss
@@ -1,0 +1,3 @@
+.loadingSpinnerMargin {
+  margin: 200px 0;
+}

--- a/source/features/blocks/ui/BlocksBrowser.tsx
+++ b/source/features/blocks/ui/BlocksBrowser.tsx
@@ -4,7 +4,6 @@ import { calculatePaging } from '../../../lib/paging';
 import RouterPagination from '../../../widgets/browsing/NavigationPagination';
 import LoadingSpinner from '../../../widgets/loading-spinner/LoadingSpinner';
 import { useNavigationFeature } from '../../navigation';
-
 import { useNetworkInfoFeature } from '../../network-info/context';
 import {
   BLOCKS_PER_PAGE_DEFAULT,
@@ -13,6 +12,7 @@ import {
 } from '../config';
 import { useBlocksFeature } from '../context';
 import BlockList from './BlockList';
+import styles from './BlocksBrowser.module.scss';
 
 interface IBlocksBrowserProps {
   epoch?: number;
@@ -75,7 +75,7 @@ const BlocksBrowser = (props: IBlocksBrowserProps) => {
       />
     </>
   ) : (
-    <LoadingSpinner />
+    <LoadingSpinner className={styles.loadingSpinnerMargin} />
   );
 };
 

--- a/source/features/blocks/ui/LatestBlocks.module.scss
+++ b/source/features/blocks/ui/LatestBlocks.module.scss
@@ -1,0 +1,3 @@
+.loadingSpinnerMargin {
+  margin: 150px 0 190px 0;
+}

--- a/source/features/blocks/ui/LatestBlocks.tsx
+++ b/source/features/blocks/ui/LatestBlocks.tsx
@@ -6,6 +6,7 @@ import { useNavigationFeature } from '../../navigation';
 import { BLOCK_BROWSE_PATH } from '../config';
 import { useBlocksFeature } from '../context';
 import BlockList from './BlockList';
+import styles from './LatestBlocks.module.scss';
 
 export const LatestBlocks = () => {
   const { actions, store } = useBlocksFeature();
@@ -38,7 +39,9 @@ export const LatestBlocks = () => {
               items={latestBlocks}
               title="Latest Blocks"
             />
-            {store.isLoadingLatestBlocksFirstTime && <LoadingSpinner />}
+            {store.isLoadingLatestBlocksFirstTime && (
+              <LoadingSpinner className={styles.loadingSpinnerMargin} />
+            )}
           </ShowMoreButtonDecorator>
         );
       }}

--- a/source/features/epochs/ui/EpochsBrowser.module.scss
+++ b/source/features/epochs/ui/EpochsBrowser.module.scss
@@ -1,0 +1,3 @@
+.loadingSpinnerMargin {
+  margin: 200px 0;
+}

--- a/source/features/epochs/ui/EpochsBrowser.tsx
+++ b/source/features/epochs/ui/EpochsBrowser.tsx
@@ -13,6 +13,7 @@ import {
 } from '../config';
 import { useEpochsFeature } from '../context';
 import EpochList from './EpochList';
+import styles from './EpochsBrowser.module.scss';
 
 const EpochsBrowser = () => {
   const navigation = useNavigationFeature();
@@ -62,7 +63,7 @@ const EpochsBrowser = () => {
       />
     </>
   ) : (
-    <LoadingSpinner />
+    <LoadingSpinner className={styles.loadingSpinnerMargin} />
   );
 };
 

--- a/source/features/epochs/ui/LatestEpochs.module.scss
+++ b/source/features/epochs/ui/LatestEpochs.module.scss
@@ -1,0 +1,3 @@
+.loadingSpinnerMargin {
+  margin: 100px 0 150px 0;
+}

--- a/source/features/epochs/ui/LatestEpochs.tsx
+++ b/source/features/epochs/ui/LatestEpochs.tsx
@@ -6,6 +6,7 @@ import { useNavigationFeature } from '../../navigation';
 import { EPOCH_BROWSE_PATH } from '../config';
 import { useEpochsFeature } from '../context';
 import EpochList from './EpochList';
+import styles from './LatestEpochs.module.scss';
 
 export const LatestEpochs = () => {
   const { actions, store } = useEpochsFeature();
@@ -39,7 +40,9 @@ export const LatestEpochs = () => {
               items={latestEpochs}
               isLoading={store.isLoadingLatestEpochsFirstTime}
             />
-            {store.isLoadingLatestEpochsFirstTime && <LoadingSpinner />}
+            {store.isLoadingLatestEpochsFirstTime && (
+              <LoadingSpinner className={styles.loadingSpinnerMargin} />
+            )}
           </ShowMoreButtonDecorator>
         );
       }}

--- a/source/features/landing-page/LandingPage.module.scss
+++ b/source/features/landing-page/LandingPage.module.scss
@@ -53,6 +53,7 @@
 }
 
 .blockList {
+  margin-top: 40px;
   margin-bottom: 139.5px;
 
   @media (max-width: 575px) {

--- a/source/features/landing-page/LandingPage.tsx
+++ b/source/features/landing-page/LandingPage.tsx
@@ -17,19 +17,16 @@ const testNetHeaderImage = require('../../public/assets/images/header/testnet.pn
 import styles from './LandingPage.module.scss';
 
 export const LandingPage = () => (
-  <>
-    <SearchBar brandType={BrandType.ENLARGED} />
-    <BlocksFeatureProvider>
-      <div className={styles.epochList}>
-        <EpochsFeatureProvider>
-          <LatestEpochs />
-        </EpochsFeatureProvider>
-      </div>
-      <div className={styles.blockList}>
-        <LatestBlocks />
-      </div>
-    </BlocksFeatureProvider>
-  </>
+  <BlocksFeatureProvider>
+    <div className={styles.epochList}>
+      <EpochsFeatureProvider>
+        <LatestEpochs />
+      </EpochsFeatureProvider>
+    </div>
+    <div className={styles.blockList}>
+      <LatestBlocks />
+    </div>
+  </BlocksFeatureProvider>
 );
 
 const StaticLayout = (props: StaticLayoutProps) => {
@@ -47,6 +44,7 @@ const StaticLayout = (props: StaticLayoutProps) => {
       )}
       <Layout>
         <Header brandType={BrandType.ENLARGED} />
+        <SearchBar brandType={BrandType.ENLARGED} />
         {props.children}
         <Footer rootClassname={styles.footer} />
       </Layout>

--- a/source/features/search/ui/AddressSearchResult.module.scss
+++ b/source/features/search/ui/AddressSearchResult.module.scss
@@ -13,3 +13,7 @@
     margin-bottom: 83px;
   }
 }
+
+.loadingSpinnerMargin {
+  margin: 150px 0;
+}

--- a/source/features/search/ui/AddressSearchResult.tsx
+++ b/source/features/search/ui/AddressSearchResult.tsx
@@ -35,7 +35,7 @@ export const AddressSearchResult = () => {
           !api.searchForAddressQuery.hasBeenExecutedAtLeastOnce ||
           store.isSearching
         ) {
-          return <LoadingSpinner />;
+          return <LoadingSpinner className={styles.loadingSpinnerMargin} />;
         } else if (addressSearchResult) {
           const {
             address,

--- a/source/features/search/ui/BlockSearchResult.module.scss
+++ b/source/features/search/ui/BlockSearchResult.module.scss
@@ -1,3 +1,7 @@
 .transactions {
   margin-top: 41px;
 }
+
+.loadingSpinnerMargin {
+  margin: 150px 0;
+}

--- a/source/features/search/ui/BlockSearchResult.tsx
+++ b/source/features/search/ui/BlockSearchResult.tsx
@@ -38,7 +38,7 @@ export const BlockSearchResult = () => {
           store.isSearching ||
           !networkInfo.store.blockHeight
         ) {
-          return <LoadingSpinner />;
+          return <LoadingSpinner className={styles.loadingSpinnerMargin} />;
         } else if (blockSearchResult) {
           return (
             <>

--- a/source/features/search/ui/EpochsSearchResult.module.scss
+++ b/source/features/search/ui/EpochsSearchResult.module.scss
@@ -29,3 +29,7 @@
     margin-bottom: 83px;
   }
 }
+
+.loadingSpinnerMargin {
+  margin: 150px 0;
+}

--- a/source/features/search/ui/EpochsSearchResult.tsx
+++ b/source/features/search/ui/EpochsSearchResult.tsx
@@ -86,7 +86,7 @@ const EpochsSearchResult = () => {
     !api.searchForEpochByNumberQuery.hasBeenExecutedAtLeastOnce ||
     queryEpochNumber !== epochSearchResult?.number
   ) {
-    return <LoadingSpinner />;
+    return <LoadingSpinner className={styles.loadingSpinnerMargin} />;
   } else if (epochSearchResult) {
     return (
       <div className={styles.container}>

--- a/source/features/search/ui/TransactionSearchResult.tsx
+++ b/source/features/search/ui/TransactionSearchResult.tsx
@@ -33,7 +33,7 @@ export const TransactionSearchResult = () => {
           !search.api.searchByIdQuery.hasBeenExecutedAtLeastOnce ||
           search.store.isSearching
         ) {
-          return <LoadingSpinner />;
+          return <LoadingSpinner className={styles.loadingSpinnerMargin} />;
         } else if (transactionSearchResult) {
           return (
             <>

--- a/source/pages/_app.module.scss
+++ b/source/pages/_app.module.scss
@@ -1,7 +1,3 @@
-.transaction {
-  margin-top: 41px;
-}
-
 .loadingSpinnerMargin {
   margin: 150px 0;
 }

--- a/source/pages/_app.tsx
+++ b/source/pages/_app.tsx
@@ -14,6 +14,7 @@ import { PageComponentWithStaticLayout } from '../lib/types';
 import '../styles/global/index.scss';
 import PolymorphThemeProvider from '../styles/theme/PolymorphThemeProvider';
 import LoadingSpinner from '../widgets/loading-spinner/LoadingSpinner';
+import styles from './_app.module.scss';
 
 const EmptyStaticLayout = (props: { children: React.ReactNode }) => (
   <>{props.children}</>
@@ -40,7 +41,13 @@ class CardanoExplorer extends App {
               <NavigationFeatureProvider>
                 <SearchFeatureProvider>
                   <StaticLayout>
-                    <NoSSR onSSR={<LoadingSpinner />}>
+                    <NoSSR
+                      onSSR={
+                        <LoadingSpinner
+                          className={styles.loadingSpinnerMargin}
+                        />
+                      }
+                    >
                       <BrowserUpdate />
                       <Component {...pageProps} />
                     </NoSSR>

--- a/source/widgets/loading-spinner/LoadingSpinner.module.scss
+++ b/source/widgets/loading-spinner/LoadingSpinner.module.scss
@@ -1,6 +1,13 @@
 .component {
-  display: table;
-  margin: 20px auto;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .icon path {
+    fill: var(--primary-highlight-color);
+  }
 
   &.big svg {
     height: 44px;
@@ -20,10 +27,6 @@
   &.small svg {
     height: 30px;
     width: 30px;
-  }
-
-  .icon path {
-    fill: var(--primary-highlight-color);
   }
 
   svg :global {

--- a/source/widgets/loading-spinner/LoadingSpinner.tsx
+++ b/source/widgets/loading-spinner/LoadingSpinner.tsx
@@ -7,6 +7,7 @@ const SpinnerSmall = require('../../public/assets/images/spinner-dark.inline.svg
 
 export interface ILoadingSpinnerProps {
   big?: boolean;
+  className?: string;
   medium?: boolean;
 }
 
@@ -14,13 +15,14 @@ export default class LoadingSpinner extends Component<ILoadingSpinnerProps> {
   public root?: HTMLDivElement | any;
 
   public render() {
-    const { big, medium } = this.props;
+    const { big, className, medium } = this.props;
 
     const componentClasses = classnames([
       styles.component,
       big ? styles.big : null,
       medium ? styles.medium : null,
       !big && !medium ? styles.small : null,
+      className,
     ]);
 
     return (


### PR DESCRIPTION
**PLEASE NOTE**: This PR is based on #219, so please merge this PR *afterwards*

This PR fixes #193 

- Includes the search bar in the static part of the landing page
- Adjusts the margin for various loading spinners in the app to visualize roughly the space that will be taken by the loaded content.