### PR TITLE
[issue-226] Add opaque bg to language options

### DIFF
--- a/source/widgets/language-switcher/LanguageSwitcher.module.scss
+++ b/source/widgets/language-switcher/LanguageSwitcher.module.scss
@@ -38,7 +38,7 @@
 }
 
 .languagesMenu {
-  background-color: transparent;
+  background-color: var(--header-background-color);
   border: 1px solid var(--hint-text-color);
   border-radius: 1px;
   color: var(--solid-text-color);


### PR DESCRIPTION
Fixes #226 by adding an opaque background for the language switch options

![Bildschirmfoto 2020-03-05 um 13 20 08](https://user-images.githubusercontent.com/172414/75981210-503dc000-5ee4-11ea-85ba-242eae9dca4b.png)
