### PR TITLE
[issue-229] Use real links for any navigation

### DIFF
--- a/source/features/address/helpers.ts
+++ b/source/features/address/helpers.ts
@@ -1,0 +1,4 @@
+import { ADDRESS_SEARCH_RESULT_PATH } from './config';
+
+export const getAddressRoute = (address: string) =>
+  `${ADDRESS_SEARCH_RESULT_PATH}?address=${address}`;

--- a/source/features/blocks/helpers.ts
+++ b/source/features/blocks/helpers.ts
@@ -1,0 +1,4 @@
+import { BLOCK_SEARCH_RESULT_PATH } from './config';
+
+export const getBlockRoute = (blockId: string) =>
+  `${BLOCK_SEARCH_RESULT_PATH}?id=${blockId}`;

--- a/source/features/blocks/ui/BlockList.module.scss
+++ b/source/features/blocks/ui/BlockList.module.scss
@@ -1,5 +1,15 @@
 .blockListContainer {
   position: relative;
+
+  a:link,
+  a:visited {
+    text-decoration: none;
+    color: var(--primary-highlight-color);
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
   :global {
     .epoch {
       width: 90px;

--- a/source/features/blocks/ui/BlockList.module.scss
+++ b/source/features/blocks/ui/BlockList.module.scss
@@ -1,15 +1,6 @@
 .blockListContainer {
   position: relative;
 
-  a:link,
-  a:visited {
-    text-decoration: none;
-    color: var(--primary-highlight-color);
-    &:hover {
-      cursor: pointer;
-    }
-  }
-
   :global {
     .epoch {
       width: 90px;

--- a/source/features/blocks/ui/BlockList.tsx
+++ b/source/features/blocks/ui/BlockList.tsx
@@ -22,9 +22,7 @@ const columns = (): Array<IColumnDefinition<IBlockOverview>> => [
     cellRender: (row: IBlockOverview) => {
       const content = `${row.epoch} / ${row.slotWithinEpoch}`;
       return isNumber(row.epoch) && isNumber(row.slotWithinEpoch) ? (
-        <LocalizedLink href={getEpochRoute(row.epoch)}>
-          <a>{content}</a>
-        </LocalizedLink>
+        <LocalizedLink href={getEpochRoute(row.epoch)}>{content}</LocalizedLink>
       ) : (
         <span>{content}</span>
       );
@@ -36,9 +34,7 @@ const columns = (): Array<IColumnDefinition<IBlockOverview>> => [
   },
   {
     cellRender: (row: IBlockOverview) => (
-      <LocalizedLink href={getBlockRoute(row.id)}>
-        <a>{row.number}</a>
-      </LocalizedLink>
+      <LocalizedLink href={getBlockRoute(row.id)}>{row.number}</LocalizedLink>
     ),
     cellValue: (row: IBlockOverview) => row,
     cssClass: 'blocksSlots',

--- a/source/features/blocks/ui/BlockList.tsx
+++ b/source/features/blocks/ui/BlockList.tsx
@@ -1,11 +1,12 @@
 import dayjs from 'dayjs';
+import { isNumber } from 'lodash';
 import { observer } from 'mobx-react-lite';
 import React, { FC } from 'react';
 import LoadingSpinner from '../../../widgets/loading-spinner/LoadingSpinner';
 import Table, { IColumnDefinition } from '../../../widgets/table/Table';
-import { EPOCH_SEARCH_RESULT_PATH } from '../../epochs/config';
-import { useNavigationFeatureOptionally } from '../../navigation';
-import { BLOCK_SEARCH_RESULT_PATH } from '../config';
+import { getEpochRoute } from '../../epochs/helpers';
+import { LocalizedLink } from '../../navigation/ui/LocalizedLink';
+import { getBlockRoute } from '../helpers';
 import { IBlockOverview } from '../types';
 import styles from './BlockList.module.scss';
 
@@ -16,27 +17,30 @@ export interface IBlockListProps {
   title: string;
 }
 
-interface IColumnsProps {
-  ignoreLinksToEpoch?: number;
-  onEpochNumberClicked: (epochNo: IBlockOverview['epoch']) => void;
-  onBlockNumberClicked: (id: IBlockOverview['id']) => void;
-}
-
-const columns = (
-  props: IColumnsProps
-): Array<IColumnDefinition<IBlockOverview>> => [
+const columns = (): Array<IColumnDefinition<IBlockOverview>> => [
   {
-    cellOnClick: (row: IBlockOverview) =>
-      props.onEpochNumberClicked?.(row.epoch),
-    cellValue: (row: IBlockOverview) => `${row.epoch} / ${row.slotWithinEpoch}`,
+    cellRender: (row: IBlockOverview) => {
+      const content = `${row.epoch} / ${row.slotWithinEpoch}`;
+      return isNumber(row.epoch) && isNumber(row.slotWithinEpoch) ? (
+        <LocalizedLink href={getEpochRoute(row.epoch)}>
+          <a>{content}</a>
+        </LocalizedLink>
+      ) : (
+        <span>{content}</span>
+      );
+    },
+    cellValue: (row: IBlockOverview) => row,
     cssClass: 'epoch',
     head: 'Epoch / Slot',
-    isCellClickable: (row: IBlockOverview) =>
-      props.ignoreLinksToEpoch !== row.epoch,
     key: 'epochsSlots',
   },
   {
-    cellOnClick: (row: IBlockOverview) => props.onBlockNumberClicked?.(row.id),
+    cellRender: (row: IBlockOverview) => (
+      <LocalizedLink href={getBlockRoute(row.id)}>
+        <a>{row.number}</a>
+      </LocalizedLink>
+    ),
+    cellValue: (row: IBlockOverview) => row,
     cssClass: 'blocksSlots',
     head: 'Block',
     key: 'number',
@@ -71,7 +75,6 @@ const columns = (
 ];
 
 const BlockList: FC<IBlockListProps> = props => {
-  const navigation = useNavigationFeatureOptionally();
   const displaysItems = props.items.length > 0;
   return (
     <div className={styles.blockListContainer}>
@@ -82,22 +85,7 @@ const BlockList: FC<IBlockListProps> = props => {
       )}
       <Table
         title={props.title}
-        columns={columns({
-          ignoreLinksToEpoch: props.ignoreLinksToEpoch,
-          onBlockNumberClicked: id =>
-            navigation?.actions.push.trigger({
-              path: BLOCK_SEARCH_RESULT_PATH,
-              query: { id },
-            }),
-          onEpochNumberClicked: epochNo => {
-            if (epochNo !== '-') {
-              navigation?.actions.push.trigger({
-                path: EPOCH_SEARCH_RESULT_PATH,
-                query: { number: epochNo },
-              });
-            }
-          },
-        })}
+        columns={columns()}
         rows={props.items.map(i => Object.assign({}, i, { key: i.id }))}
         withoutHeaders={!displaysItems && props.isLoading}
       />

--- a/source/features/blocks/ui/BlockSummary.tsx
+++ b/source/features/blocks/ui/BlockSummary.tsx
@@ -1,8 +1,11 @@
 import dayjs from 'dayjs';
+import { isNumber } from 'lodash';
 import { observer } from 'mobx-react-lite';
 import DividerWithTitle from '../../../widgets/divider-with-title/DividerWithTitle';
 import { EPOCH_SEARCH_RESULT_PATH } from '../../epochs/config';
+import { getEpochRoute } from '../../epochs/helpers';
 import { NavigationActions } from '../../navigation';
+import { LocalizedLink } from '../../navigation/ui/LocalizedLink';
 import { ITransactionDetails } from '../../transactions/types';
 import { BLOCK_SEARCH_RESULT_PATH } from '../config';
 import { IBlockDetailed } from '../types';
@@ -49,9 +52,13 @@ const BlockSummary = (props: BlockSummaryProps) => {
           <div className={styles.infoRow}>
             <div className={styles.infoLabel}>Epoch</div>
             <div className={styles.infoValue}>
-              <span onClick={onEpochNumberClick(props.epoch)}>
-                {props.epoch}
-              </span>
+              {isNumber(props.epoch) ? (
+                <LocalizedLink href={getEpochRoute(props.epoch)}>
+                  {props.epoch}
+                </LocalizedLink>
+              ) : (
+                props.epoch
+              )}
             </div>
           </div>
           <div className={styles.infoRow}>

--- a/source/features/blocks/ui/LatestBlocks.tsx
+++ b/source/features/blocks/ui/LatestBlocks.tsx
@@ -25,13 +25,11 @@ export const LatestBlocks = () => {
         const { latestBlocks } = store;
         return (
           <ShowMoreButtonDecorator
+            href={BLOCK_BROWSE_PATH}
             label={'show more'}
             isHidden={
               store.isLoadingLatestBlocksFirstTime ||
               store.latestBlocks.length < 10
-            }
-            onClick={() =>
-              navigation.actions.push.trigger({ path: BLOCK_BROWSE_PATH })
             }
           >
             <BlockList

--- a/source/features/epochs/helpers.ts
+++ b/source/features/epochs/helpers.ts
@@ -1,0 +1,4 @@
+import { EPOCH_SEARCH_RESULT_PATH } from './config';
+
+export const getEpochRoute = (epoch: number) =>
+  `${EPOCH_SEARCH_RESULT_PATH}?number=${epoch}`;

--- a/source/features/epochs/ui/EpochList.module.scss
+++ b/source/features/epochs/ui/EpochList.module.scss
@@ -1,5 +1,15 @@
 .epochListContainer {
   position: relative;
+
+  a:link,
+  a:visited {
+    text-decoration: none;
+    color: var(--primary-highlight-color);
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
   :global {
     .epoch {
       width: 90px;

--- a/source/features/epochs/ui/EpochList.module.scss
+++ b/source/features/epochs/ui/EpochList.module.scss
@@ -1,15 +1,6 @@
 .epochListContainer {
   position: relative;
 
-  a:link,
-  a:visited {
-    text-decoration: none;
-    color: var(--primary-highlight-color);
-    &:hover {
-      cursor: pointer;
-    }
-  }
-
   :global {
     .epoch {
       width: 90px;

--- a/source/features/epochs/ui/EpochList.tsx
+++ b/source/features/epochs/ui/EpochList.tsx
@@ -6,8 +6,8 @@ import CircularProgress, {
 } from '../../../widgets/circular-progress/CircularProgress';
 import LoadingSpinner from '../../../widgets/loading-spinner/LoadingSpinner';
 import Table, { IColumnDefinition } from '../../../widgets/table/Table';
-import { useNavigationFeatureOptionally } from '../../navigation';
-import { EPOCH_SEARCH_RESULT_PATH } from '../config';
+import { LocalizedLink } from '../../navigation/ui/LocalizedLink';
+import { getEpochRoute } from '../helpers';
 import { IEpochOverview } from '../types';
 import styles from './EpochList.module.scss';
 
@@ -20,25 +20,28 @@ export interface IEpochListProps {
 
 interface IColumnsProps {
   currentEpoch: number;
-  onEpochNumberClicked: (epochNo: number) => void;
 }
 
 const columns = (
   props: IColumnsProps
 ): Array<IColumnDefinition<IEpochOverview>> => [
   {
-    cellOnClick: (row: IEpochOverview) =>
-      props.onEpochNumberClicked?.(row.number),
     cellRender: (value: any) => {
-      return props.currentEpoch === value.epoch ? (
-        <CircularProgress
-          percentage={value.percentage}
-          size={CircularProgressSize.SMALL}
-          showText
-          text={value.epoch}
-        />
-      ) : (
-        value.epoch
+      const epoch =
+        props.currentEpoch === value.epoch ? (
+          <CircularProgress
+            percentage={value.percentage}
+            size={CircularProgressSize.SMALL}
+            showText
+            text={value.epoch}
+          />
+        ) : (
+          value.epoch
+        );
+      return (
+        <LocalizedLink href={getEpochRoute(value.epoch)}>
+          <a>{epoch}</a>
+        </LocalizedLink>
       );
     },
     cellValue: (row: IEpochOverview) => ({
@@ -92,7 +95,6 @@ const EpochList: FC<IEpochListProps> = ({
   items,
   isLoading,
 }) => {
-  const navigation = useNavigationFeatureOptionally();
   const displaysItems = items.length > 0;
   return (
     <div className={styles.epochListContainer}>
@@ -103,16 +105,7 @@ const EpochList: FC<IEpochListProps> = ({
       )}
       <Table
         title={title}
-        columns={columns({
-          currentEpoch,
-          onEpochNumberClicked: epochNo =>
-            navigation?.actions.push.trigger({
-              path: EPOCH_SEARCH_RESULT_PATH,
-              query: {
-                number: epochNo,
-              },
-            }),
-        })}
+        columns={columns({ currentEpoch })}
         rows={items.map(i => Object.assign({}, i, { key: i.number }))}
         withoutHeaders={!displaysItems && isLoading}
       />

--- a/source/features/epochs/ui/EpochList.tsx
+++ b/source/features/epochs/ui/EpochList.tsx
@@ -39,9 +39,7 @@ const columns = (
           value.epoch
         );
       return (
-        <LocalizedLink href={getEpochRoute(value.epoch)}>
-          <a>{epoch}</a>
-        </LocalizedLink>
+        <LocalizedLink href={getEpochRoute(value.epoch)}>{epoch}</LocalizedLink>
       );
     },
     cellValue: (row: IEpochOverview) => ({

--- a/source/features/epochs/ui/LatestEpochs.tsx
+++ b/source/features/epochs/ui/LatestEpochs.tsx
@@ -25,13 +25,11 @@ export const LatestEpochs = () => {
         const { latestEpochs } = store;
         return (
           <ShowMoreButtonDecorator
+            href={EPOCH_BROWSE_PATH}
             label={'show more'}
             isHidden={
               store.isLoadingLatestEpochsFirstTime ||
               store.latestEpochs.length < 5
-            }
-            onClick={() =>
-              navigation.actions.push.trigger({ path: EPOCH_BROWSE_PATH })
             }
           >
             <EpochList

--- a/source/features/errors/PageNotFoundError.tsx
+++ b/source/features/errors/PageNotFoundError.tsx
@@ -35,7 +35,9 @@ export default class Error extends Component<IErrorProps> {
           <p className={styles.bottomContainerText}>{notFoundText}</p>
           <div className={styles.bottomContainerLinks}>
             <LocalizedLink href="/">
-              <a className={styles.bottomContainerLink}>Blockchain Explorer</a>
+              <span className={styles.bottomContainerLink}>
+                Blockchain Explorer
+              </span>
             </LocalizedLink>
             <div className={styles.bottomContainerLinksSeparator} />
             <a

--- a/source/features/navigation/ui/LocalizedLink.module.scss
+++ b/source/features/navigation/ui/LocalizedLink.module.scss
@@ -1,0 +1,10 @@
+.link {
+  &:link,
+  &:visited {
+    text-decoration: none;
+    color: var(--primary-highlight-color);
+    &:hover {
+      cursor: pointer;
+    }
+  }
+}

--- a/source/features/navigation/ui/LocalizedLink.tsx
+++ b/source/features/navigation/ui/LocalizedLink.tsx
@@ -1,9 +1,12 @@
 import Link, { LinkProps } from 'next/link';
 import React from 'react';
 import { useI18nFeature } from '../../i18n/context';
+import styles from './LocalizedLink.module.scss';
 
 export const LocalizedLink = (
-  props: LinkProps & { children: React.ReactNode }
+  props: LinkProps & {
+    children: React.ReactNode;
+  }
 ) => {
   const i18n = useI18nFeature();
   return (
@@ -12,7 +15,7 @@ export const LocalizedLink = (
       href={`/[locale]${props.href}`}
       as={`/${i18n.store.locale}${props.href}`}
     >
-      {props.children}
+      <a className={styles.link}>{props.children}</a>
     </Link>
   );
 };

--- a/source/features/navigation/ui/LocalizedLink.tsx
+++ b/source/features/navigation/ui/LocalizedLink.tsx
@@ -9,7 +9,7 @@ export const LocalizedLink = (
   return (
     <Link
       {...props}
-      href={`/[locale]/${props.href}`}
+      href={`/[locale]${props.href}`}
       as={`/${i18n.store.locale}${props.href}`}
     >
       {props.children}

--- a/source/features/search/ui/TransactionSearchResult.tsx
+++ b/source/features/search/ui/TransactionSearchResult.tsx
@@ -46,7 +46,6 @@ export const TransactionSearchResult = () => {
               <div className={styles.transaction}>
                 <TransactionInfo
                   dontLinkToTransaction
-                  navigation={navigation?.actions}
                   title="Transaction"
                   {...transactionSearchResult}
                 />

--- a/source/features/stake-pools/components/UnmoderatedDataWarning.tsx
+++ b/source/features/stake-pools/components/UnmoderatedDataWarning.tsx
@@ -21,9 +21,7 @@ export default ({ onAcceptUnmoderatedData }: IUnmoderatedDataWarning) => (
         <p>Do you want to see unmoderated content?</p>
       </div>
       <div className={styles.contentBottom}>
-        <LocalizedLink href="/">
-          <a>Leave this page</a>
-        </LocalizedLink>
+        <LocalizedLink href="/">Leave this page</LocalizedLink>
         <button onClick={onAcceptUnmoderatedData}>
           Yes, show unmoderated content
         </button>

--- a/source/features/transactions/components/TransactionInfo.module.scss
+++ b/source/features/transactions/components/TransactionInfo.module.scss
@@ -5,11 +5,6 @@ $medium-breakpoint: 780px;
   max-width: 872px;
   width: 100%;
 
-  a:link,
-  a:visited {
-    text-decoration: none;
-  }
-
   .header {
     margin-bottom: 41px;
   }

--- a/source/features/transactions/components/TransactionInfo.module.scss
+++ b/source/features/transactions/components/TransactionInfo.module.scss
@@ -5,6 +5,11 @@ $medium-breakpoint: 780px;
   max-width: 872px;
   width: 100%;
 
+  a:link,
+  a:visited {
+    text-decoration: none;
+  }
+
   .header {
     margin-bottom: 41px;
   }
@@ -96,7 +101,6 @@ $medium-breakpoint: 780px;
         .output {
           align-items: center;
           color: var(--primary-highlight-color);
-          cursor: pointer;
           display: flex;
           font-family: ProximaNova, sans-serif;
           letter-spacing: 0.4px;

--- a/source/features/transactions/components/TransactionInfo.tsx
+++ b/source/features/transactions/components/TransactionInfo.tsx
@@ -53,9 +53,9 @@ const TransactionInfo = (props: ITransactionInfoProps) => {
               <div className={styles.id}>{props.id}</div>
             ) : (
               <LocalizedLink href={getTransactionRoute(props.id)}>
-                <a className={classnames([styles.id, styles.linkedId])}>
+                <span className={classnames([styles.id, styles.linkedId])}>
                   {props.id}
-                </a>
+                </span>
               </LocalizedLink>
             )}
             <div className={styles.includedAt}>{includedAt}</div>
@@ -75,9 +75,9 @@ const TransactionInfo = (props: ITransactionInfoProps) => {
                   </div>
                 ) : (
                   <LocalizedLink href={getAddressRoute(input.address)} key={i}>
-                    <a className={styles.input}>
+                    <span className={styles.input}>
                       <TransactionAddress address={input.address} />
-                    </a>
+                    </span>
                   </LocalizedLink>
                 )
               )}
@@ -99,9 +99,9 @@ const TransactionInfo = (props: ITransactionInfoProps) => {
                   </div>
                 ) : (
                   <LocalizedLink href={getAddressRoute(output.address)} key={i}>
-                    <a className={styles.output}>
+                    <span className={styles.output}>
                       <TransactionAddress address={output.address} />
-                    </a>
+                    </span>
                   </LocalizedLink>
                 )
               )}

--- a/source/features/transactions/components/TransactionInfo.tsx
+++ b/source/features/transactions/components/TransactionInfo.tsx
@@ -4,9 +4,9 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 import DividerWithTitle from '../../../widgets/divider-with-title/DividerWithTitle';
-import { ADDRESS_SEARCH_RESULT_PATH } from '../../address/config';
-import { NavigationActions } from '../../navigation';
-import { TRANSACTION_SEARCH_RESULT_PATH } from '../config';
+import { getAddressRoute } from '../../address/helpers';
+import { LocalizedLink } from '../../navigation/ui/LocalizedLink';
+import { getTransactionRoute } from '../helpers';
 import { ITransactionDetails } from '../types';
 import styles from './TransactionInfo.module.scss';
 
@@ -16,10 +16,20 @@ const SEVEN_DAYS = 7 * 24 * 3600000;
 
 export interface ITransactionInfoProps extends ITransactionDetails {
   highlightAddress?: string;
-  navigation?: NavigationActions;
   title?: string;
   dontLinkToTransaction?: boolean;
 }
+
+const TransactionAddress = (props: { address: string }) =>
+  props.address.length <= 34 ? (
+    <span>{props.address}</span>
+  ) : (
+    <>
+      <div>{props.address.toString().substring(0, 16)}</div>
+      {'...'}
+      <div>{props.address.toString().substring(props.address.length - 16)}</div>
+    </>
+  );
 
 const TransactionInfo = (props: ITransactionInfoProps) => {
   const duration = dayjs().diff(dayjs(props.includedAt));
@@ -29,24 +39,6 @@ const TransactionInfo = (props: ITransactionInfoProps) => {
   } else {
     includedAt = dayjs().to(dayjs(props.includedAt));
   }
-  const onAddressClick = (address: string) => {
-    if (!address) {
-      return;
-    }
-    props.navigation?.push.trigger({
-      path: ADDRESS_SEARCH_RESULT_PATH,
-      query: { address },
-    });
-  };
-  const onIdClick = (id: ITransactionDetails['id']) => {
-    if (!id) {
-      return;
-    }
-    props.navigation?.push.trigger({
-      path: TRANSACTION_SEARCH_RESULT_PATH,
-      query: { id },
-    });
-  };
   return (
     <div className={styles.transactionInfoContainer}>
       {props.title && (
@@ -57,77 +49,62 @@ const TransactionInfo = (props: ITransactionInfoProps) => {
       <div className={styles.transactionInfoRowContainer}>
         <div className={styles.addresses}>
           <div className={styles.infoRow}>
-            <div
-              className={classnames([
-                styles.id,
-                props.dontLinkToTransaction ? null : styles.linkedId,
-              ])}
-            >
-              <span
-                onClick={() =>
-                  !props.dontLinkToTransaction && onIdClick(props.id)
-                }
-              >
-                {props.id}
-              </span>
-            </div>
+            {props.dontLinkToTransaction ? (
+              <div className={styles.id}>{props.id}</div>
+            ) : (
+              <LocalizedLink href={getTransactionRoute(props.id)}>
+                <a className={classnames([styles.id, styles.linkedId])}>
+                  {props.id}
+                </a>
+              </LocalizedLink>
+            )}
             <div className={styles.includedAt}>{includedAt}</div>
           </div>
           <div className={styles.infoRow}>
             <div className={styles.inputs}>
-              {props.inputs.map((input, i) => (
-                <div
-                  key={i}
-                  className={
-                    input.address === props.highlightAddress
-                      ? styles.highlightAddress
-                      : styles.input
-                  }
-                  onClick={() => onAddressClick(input.address)}
-                >
-                  {input.address.length <= 34 ? (
-                    <span>{input.address}</span>
-                  ) : (
-                    <>
-                      <div>{input.address.substring(0, 16)}</div>
-                      {'...'}
-                      <div>
-                        {input.address.substring(input.address.length - 16)}
-                      </div>
-                    </>
-                  )}
-                </div>
-              ))}
+              {props.inputs.map((input, i) =>
+                input.address === props.highlightAddress ? (
+                  <div
+                    className={classnames([
+                      styles.input,
+                      styles.highlightAddress,
+                    ])}
+                    key={i}
+                  >
+                    <TransactionAddress address={input.address} />
+                  </div>
+                ) : (
+                  <LocalizedLink href={getAddressRoute(input.address)} key={i}>
+                    <a className={styles.input}>
+                      <TransactionAddress address={input.address} />
+                    </a>
+                  </LocalizedLink>
+                )
+              )}
             </div>
             <div className={styles.nextIcon}>
               <ArrowNext />
             </div>
             <div className={styles.outputs}>
-              {props.outputs.map((output, i) => (
-                <div
-                  key={i}
-                  className={
-                    output.address === props.highlightAddress
-                      ? styles.highlightAddress
-                      : styles.output
-                  }
-                  onClick={() => onAddressClick(output.address)}
-                >
-                  {output.address.length <= 34 ? (
-                    <span>{output.address}</span>
-                  ) : (
-                    <>
-                      <div>{output.address.toString().substring(0, 16)}</div>
-                      {'...'}
-                      <div>
-                        {output.address
-                          .toString()
-                          .substring(output.address.length - 16)}
-                      </div>
-                    </>
-                  )}
-                </div>
-              ))}
+              {props.outputs.map((output, i) =>
+                output.address === props.highlightAddress ? (
+                  <div
+                    className={classnames([
+                      styles.output,
+                      styles.highlightAddress,
+                    ])}
+                    key={i}
+                  >
+                    <TransactionAddress address={output.address} />
+                  </div>
+                ) : (
+                  <LocalizedLink href={getAddressRoute(output.address)} key={i}>
+                    <a className={styles.output}>
+                      <TransactionAddress address={output.address} />
+                    </a>
+                  </LocalizedLink>
+                )
+              )}
             </div>
           </div>
         </div>

--- a/source/features/transactions/components/TransactionList.tsx
+++ b/source/features/transactions/components/TransactionList.tsx
@@ -2,7 +2,6 @@ import { observer } from 'mobx-react-lite';
 import React from 'react';
 import DividerWithTitle from '../../../widgets/divider-with-title/DividerWithTitle';
 import LoadingSpinner from '../../../widgets/loading-spinner/LoadingSpinner';
-import { useNavigationFeatureOptionally } from '../../navigation';
 import TransactionInfo, { ITransactionInfoProps } from './TransactionInfo';
 import styles from './TransactionList.module.scss';
 
@@ -13,7 +12,6 @@ export interface ITransactionListProps {
 }
 
 const TransactionList = (props: ITransactionListProps) => {
-  const navigation = useNavigationFeatureOptionally();
   const hasItems = props.items.length > 0;
   return (
     <div className={styles.transactionListContainer}>
@@ -27,7 +25,7 @@ const TransactionList = (props: ITransactionListProps) => {
       </div>
       {props.items.map((item, index) => (
         <div key={`transaction_${index}`} className={styles.transactionListRow}>
-          <TransactionInfo navigation={navigation?.actions} {...item} />
+          <TransactionInfo {...item} />
         </div>
       ))}
     </div>

--- a/source/features/transactions/helpers.ts
+++ b/source/features/transactions/helpers.ts
@@ -1,0 +1,4 @@
+import { TRANSACTION_SEARCH_RESULT_PATH } from './config';
+
+export const getTransactionRoute = (txId: string) =>
+  `${TRANSACTION_SEARCH_RESULT_PATH}?id=${txId}`;

--- a/source/widgets/decorators/ShowMoreButtonDecorator.module.scss
+++ b/source/widgets/decorators/ShowMoreButtonDecorator.module.scss
@@ -6,15 +6,17 @@
   @media (max-width: 575px) {
     justify-content: flex-start;
   }
+
   .showMoreButton {
-    align-items: center;
-    background-color: var(--primary-highlight-color);
-    border-radius: 2px;
+    text-decoration: none;
     color: var(--primary-bg-color);
-    display: flex;
     font-family: ProximaNova, sans-serif;
     font-size: 12px;
     font-weight: 600;
+    align-items: center;
+    background-color: var(--primary-highlight-color);
+    border-radius: 2px;
+    display: flex;
     height: 25px;
     justify-content: center;
     letter-spacing: 0.4px;

--- a/source/widgets/decorators/ShowMoreButtonDecorator.tsx
+++ b/source/widgets/decorators/ShowMoreButtonDecorator.tsx
@@ -15,7 +15,7 @@ const ShowMoreButtonDecorator = (props: IShowMoreButtonDecorator) => (
     {!props.isHidden && (
       <div className={styles.root}>
         <LocalizedLink href={props.href}>
-          <a className={styles.showMoreButton}>{props.label}</a>
+          <span className={styles.showMoreButton}>{props.label}</span>
         </LocalizedLink>
       </div>
     )}

--- a/source/widgets/decorators/ShowMoreButtonDecorator.tsx
+++ b/source/widgets/decorators/ShowMoreButtonDecorator.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Button } from 'react-polymorph/lib/components/Button';
+import { LocalizedLink } from '../../features/navigation/ui/LocalizedLink';
 import styles from './ShowMoreButtonDecorator.module.scss';
 
 export interface IShowMoreButtonDecorator {
+  href: string;
   label: string;
   isHidden?: boolean;
-  onClick?: (...params: any[]) => void;
   children: React.ReactNode;
 }
 
@@ -14,11 +14,9 @@ const ShowMoreButtonDecorator = (props: IShowMoreButtonDecorator) => (
     {props.children}
     {!props.isHidden && (
       <div className={styles.root}>
-        <Button
-          className={styles.showMoreButton}
-          label={props.label}
-          onClick={props.onClick}
-        />
+        <LocalizedLink href={props.href}>
+          <a className={styles.showMoreButton}>{props.label}</a>
+        </LocalizedLink>
       </div>
     )}
   </>

--- a/source/widgets/layout/Header.tsx
+++ b/source/widgets/layout/Header.tsx
@@ -41,7 +41,7 @@ export const Header = observer((props: IHeaderProps) => {
   const stakePoolLink =
     environment.CARDANO.ERA === CardanoEra.SHELLEY ? (
       <LocalizedLink href="/stake-pools">
-        <a className={stakePoolsClassName}>Stake Pools</a>
+        <span className={stakePoolsClassName}>Stake Pools</span>
       </LocalizedLink>
     ) : null;
   const stakePoolTriangleStyle = stakePoolLink ? '' : styles.stakePoolTriangle;
@@ -55,19 +55,13 @@ export const Header = observer((props: IHeaderProps) => {
         <div className={styles.brandType}>
           <div className={styles.logoContainer}>
             <LocalizedLink href="/">
-              <a>
-                <CardanoLogo className={styles.logo} />
-              </a>
+              <CardanoLogo className={styles.logo} />
             </LocalizedLink>
           </div>
           <div className={styles.titleContainer}>
             <LocalizedLink href="/">
-              <a>
-                <span className={styles.cardanoTitle}>Cardano</span>
-                <span className={styles.explorerTitle}>
-                  Blockchain Explorer
-                </span>
-              </a>
+              <span className={styles.cardanoTitle}>Cardano</span>
+              <span className={styles.explorerTitle}>Blockchain Explorer</span>
             </LocalizedLink>
             {testnetSubtitle}
           </div>
@@ -76,7 +70,7 @@ export const Header = observer((props: IHeaderProps) => {
               <div className={styles.tabLeftLine} />
               <div className={styles.tabCircle} />
               <LocalizedLink href="/">
-                <a className={indexClassName}>Epochs & Blocks</a>
+                <span className={indexClassName}>Epochs & Blocks</span>
               </LocalizedLink>
               <div className={styles.tabCircle} />
               {stakePoolLink}

--- a/stories/blocks.stories.tsx
+++ b/stories/blocks.stories.tsx
@@ -101,10 +101,7 @@ storiesOf('Blocks|List', module)
     <BlockList title="Blocks" items={blocks.slice(0, 5)} isLoading={false} />
   ))
   .add('with show more button', () => (
-    <ShowMoreButtonDecorator
-      label={'show more'}
-      onClick={action('show more clicked')}
-    >
+    <ShowMoreButtonDecorator label={'show more'} href={''}>
       <BlockList title="Blocks" items={blocks.slice(0, 5)} isLoading={false} />
     </ShowMoreButtonDecorator>
   ))


### PR DESCRIPTION
Fixes #229 by refactoring all internal navigation to use `<LocalizedLink>`, which creates a real (<a> tag) link instead of relying on internal routing (which is less flexible for the user)