### PR TITLE
[issue-216] Reverse list in blocks browsers

### DIFF
--- a/source/features/blocks/ui/BlocksBrowser.tsx
+++ b/source/features/blocks/ui/BlocksBrowser.tsx
@@ -78,8 +78,8 @@ const BlocksBrowser = (props: IBlocksBrowserProps) => {
         title={props.title}
         items={
           isBrowsingInEpoch
-            ? browsedBlocks.slice().reverse()
-            : browsedBlocks.slice()
+            ? browsedBlocks.slice()
+            : browsedBlocks.slice().reverse()
         }
       />
       <RouterPagination


### PR DESCRIPTION
As discussed in #216 the intended UX is to browse blocks like they are continously written into a notebook, with the last page being appended to.