### PR TITLE
[issue-241] Show loading state for manual browsing

### DIFF
--- a/source/features/blocks/ui/BlocksBrowser.tsx
+++ b/source/features/blocks/ui/BlocksBrowser.tsx
@@ -42,6 +42,8 @@ const BlocksBrowser = (props: IBlocksBrowserProps) => {
     totalPages: 0,
   });
 
+  const [isChangingPage, setIsChangingPage] = useState(false);
+
   useObservableEffect(
     observedProps => {
       const { blockHeight } = networkInfo.store;
@@ -69,6 +71,12 @@ const BlocksBrowser = (props: IBlocksBrowserProps) => {
     }
   );
 
+  useObservableEffect(() => {
+    if (isChangingPage && !apiQuery.isExecuting) {
+      setIsChangingPage(false);
+    }
+  });
+
   return !apiQuery.hasBeenExecutedAtLeastOnce ||
     apiQuery.isExecutingTheFirstTime ? (
     <LoadingSpinner className={styles.loadingSpinnerMargin} />
@@ -76,6 +84,7 @@ const BlocksBrowser = (props: IBlocksBrowserProps) => {
     <>
       <BlockList
         title={props.title}
+        isLoading={isChangingPage && apiQuery.isExecuting}
         items={
           isBrowsingInEpoch
             ? browsedBlocks.slice()
@@ -85,6 +94,7 @@ const BlocksBrowser = (props: IBlocksBrowserProps) => {
       <RouterPagination
         currentPage={paging.currentPage}
         itemsPerPage={paging.itemsPerPage}
+        onChangePage={() => setIsChangingPage(true)}
         totalPages={paging.totalPages}
       />
     </>

--- a/source/widgets/browsing/NavigationPagination.tsx
+++ b/source/widgets/browsing/NavigationPagination.tsx
@@ -6,6 +6,7 @@ import Pagination from './Pagination';
 export interface IPaginationProps {
   currentPage: number;
   itemsPerPage: number;
+  onChangePage?: (page: number) => void;
   totalPages: number;
 }
 
@@ -21,6 +22,7 @@ const NavigationPagination = (props: IPaginationProps) => {
         perPage: itemsPerPage,
       },
     });
+    props.onChangePage?.(page);
   };
   return (
     <Pagination


### PR DESCRIPTION
Fixes #241 by showing the loading state of the block list when browsing manually between pages.