### PR TITLE
[issue 249] - Adding missing translations for No results page

### DIFF
--- a/source/features/i18n/translations/de.json
+++ b/source/features/i18n/translations/de.json
@@ -105,6 +105,9 @@
     "en": "Englisch",
     "ja": "Japanisch"
   },
+  "noSearchResult": {
+    "pageTitle": "Keine Ergebnisse"
+  },
   "outdatedBrowser": {
     "pageTitle": "Veralteter Browser",
     "text": "Ihr Web-Browser ist veraltet.",

--- a/source/features/i18n/translations/en.json
+++ b/source/features/i18n/translations/en.json
@@ -105,6 +105,9 @@
     "en": "English",
     "ja": "Japanese"
   },
+  "noSearchResult": {
+    "pageTitle": "No results"
+  },
   "outdatedBrowser": {
     "pageTitle": "Outdated browser",
     "text": "Your web browser is out of date",

--- a/source/features/i18n/translations/ja.json
+++ b/source/features/i18n/translations/ja.json
@@ -105,6 +105,9 @@
     "en": "英語",
     "ja": "日本語"
   },
+  "noSearchResult": {
+    "pageTitle": "結果がありません"
+  },
   "outdatedBrowser": {
     "pageTitle": "旧ブラウザー",
     "text": "ご使用のウェブブラウザーは旧バージョンです",

--- a/source/features/search/ui/pages/NoSearchResultPage.tsx
+++ b/source/features/search/ui/pages/NoSearchResultPage.tsx
@@ -28,11 +28,11 @@ const NoSearchResultsPage = () => {
 };
 
 const StaticLayout = (props: StaticLayoutProps) => {
-  const i18n = useI18nFeature();
+  const i18n = useI18nFeature().store;
   return (
     <Layout>
       <Head>
-        <title>{i18n.store.translate('noSearchResult.pageTitle')}</title>
+        <title>{i18n.translate('noSearchResult.pageTitle')}</title>
       </Head>
       <Header brandType={BrandType.ENLARGED} />
       {props.children}


### PR DESCRIPTION
[issue 249] - Adding missing translations for No results page


<img width="689" alt="Screenshot 2020-03-18 14 06 25" src="https://user-images.githubusercontent.com/15862062/77002778-afa6c180-6921-11ea-9ce7-df6f5af44750.png">
<img width="675" alt="Screenshot 2020-03-18 14 06 17" src="https://user-images.githubusercontent.com/15862062/77002784-b0d7ee80-6921-11ea-9f82-6f1856d27b19.png">
<img width="692" alt="Screenshot 2020-03-18 14 06 08" src="https://user-images.githubusercontent.com/15862062/77002785-b1708500-6921-11ea-87ca-f3a2f0c86d88.png">


