### PR TITLE
[issue-268] Simplify and improve blocks browser

### DIFF
--- a/source/features/blocks/api/transformers.ts
+++ b/source/features/blocks/api/transformers.ts
@@ -3,7 +3,7 @@ import {
   BlockDetailsFragment,
   BlockOverviewFragment,
 } from '../../../../generated/typings/graphql-schema';
-import { isNotNull } from '../../../lib/types';
+import { isDefined } from '../../../lib/types';
 import { transactionDetailsTransformer } from '../../transactions/api/transformers';
 import { IBlockDetailed, IBlockOverview } from '../types';
 
@@ -44,7 +44,7 @@ export const blockDetailsTransformer = (
     number: b.previousBlock?.number || '-',
   },
   transactions: b.transactions
-    .filter(isNotNull)
+    .filter(isDefined)
     .map(transactionDetailsTransformer),
 });
 

--- a/source/features/blocks/ui/BlocksBrowser.tsx
+++ b/source/features/blocks/ui/BlocksBrowser.tsx
@@ -1,7 +1,8 @@
+import { debounce } from 'lodash';
 import { observer } from 'mobx-react-lite';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useObservableEffect } from '../../../lib/mobx/react';
-import { calculatePaging } from '../../../lib/paging';
+import { calculatePaging, ICalculatePagingOutputs } from '../../../lib/paging';
 import RouterPagination from '../../../widgets/browsing/NavigationPagination';
 import LoadingSpinner from '../../../widgets/loading-spinner/LoadingSpinner';
 import { useNavigationFeature } from '../../navigation';
@@ -12,6 +13,7 @@ import {
   BLOCKS_PER_PAGE_MINIMUM,
 } from '../config';
 import { useBlocksFeature } from '../context';
+import { IBlocksFeature } from '../index';
 import BlockList from './BlockList';
 import styles from './BlocksBrowser.module.scss';
 
@@ -24,53 +26,71 @@ interface IBlocksBrowserProps {
   totalItems?: number;
 }
 
+const triggerBrowseQuery = (
+  blocks: IBlocksFeature,
+  p: ICalculatePagingOutputs,
+  epoch?: number
+) => {
+  blocks.actions.browseBlocks.trigger({
+    epoch,
+    page: p.currentPage,
+    perPage: p.itemsPerPage,
+  });
+};
+
+const triggerBrowseQueryDebounced = debounce(triggerBrowseQuery, 400);
+
 const BlocksBrowser = (props: IBlocksBrowserProps) => {
-  const navigation = useNavigationFeature();
   const networkInfo = useNetworkInfoFeature();
+  const navigation = useNavigationFeature();
   const blocks = useBlocksFeature();
+
+  // Check block height or total items
+  const { blockHeight } = networkInfo.store;
+  const totalItems = props.totalItems ?? blockHeight;
+  if (!totalItems) {
+    return <LoadingSpinner className={styles.loadingSpinnerMargin} />;
+  }
+  // Setup rest of dependencies:
   const { browsedBlocks } = blocks.store;
   const isBrowsingInEpoch = !!props.epoch;
+  const { page, perPage } = navigation.store.query;
 
   const apiQuery =
     props.epoch != null
       ? blocks.api.getBlocksInEpochQuery
       : blocks.api.getBlocksInRangeQuery;
 
-  const [paging, setPaging] = useState({
-    currentPage: 0,
-    itemsPerPage: 0,
-    totalPages: 0,
+  const paging = calculatePaging({
+    currentPage: page as string,
+    perPage: perPage as string,
+    perPageDefault: props.perPageDefault ?? BLOCKS_PER_PAGE_DEFAULT,
+    perPageMaximum: props.perPageMaximum ?? BLOCKS_PER_PAGE_MAXIMUM,
+    perPageMinimum: props.perPageMinimum ?? BLOCKS_PER_PAGE_MINIMUM,
+    totalItems,
   });
 
-  const [isChangingPage, setIsChangingPage] = useState(false);
+  // Always immediately trigger query exactly once after rendering:
+  useEffect(() => {
+    triggerBrowseQuery(blocks, paging, props.epoch);
+  }, []);
 
-  useObservableEffect(
-    observedProps => {
-      const { blockHeight } = networkInfo.store;
-      const totalItems = observedProps?.totalItems ?? blockHeight;
-      if (!totalItems) {
-        return;
-      }
-      const p = calculatePaging({
-        currentPage: navigation.store.query.page as string,
-        perPage: navigation.store.query.perPage as string,
-        perPageDefault: props.perPageDefault ?? BLOCKS_PER_PAGE_DEFAULT,
-        perPageMaximum: props.perPageMaximum ?? BLOCKS_PER_PAGE_MAXIMUM,
-        perPageMinimum: props.perPageMinimum ?? BLOCKS_PER_PAGE_MINIMUM,
-        totalItems,
-      });
-      setPaging(p);
-      blocks.actions.browseBlocks.trigger({
-        epoch: props.epoch,
-        page: p.currentPage,
-        perPage: p.itemsPerPage,
-      });
-    },
-    {
-      totalItems: props.totalItems,
+  // Debounce query to avoid unnecessary queries on rapid page switching
+  useEffect(() => {
+    if (apiQuery.hasBeenExecutedAtLeastOnce) {
+      triggerBrowseQueryDebounced(blocks, paging, props.epoch);
     }
-  );
+  }, [paging.totalPages, paging.currentPage, paging.itemsPerPage, props.epoch]);
 
+  // Trigger query on last page whenever total items change
+  useEffect(() => {
+    if (paging.currentPage === paging.totalPages && !apiQuery.isExecuting) {
+      triggerBrowseQuery(blocks, paging, props.epoch);
+    }
+  }, [totalItems]);
+
+  // Set special state for showing loading spinner on manual browsing
+  const [isChangingPage, setIsChangingPage] = useState(false);
   useObservableEffect(() => {
     if (isChangingPage && !apiQuery.isExecuting) {
       setIsChangingPage(false);

--- a/source/features/epochs/store.ts
+++ b/source/features/epochs/store.ts
@@ -8,7 +8,7 @@ import { ActionProps, createActionBindings } from '../../lib/ActionBinding';
 import { GraphQLRequestVariables } from '../../lib/graphql/GraphQLRequest';
 import Reaction, { createReactions } from '../../lib/mobx/Reaction';
 import { Store } from '../../lib/Store';
-import { isNotNull } from '../../lib/types';
+import { isDefined } from '../../lib/types';
 import { EpochsApi } from './api';
 import { epochOverviewTransformer } from './api/transformers';
 import {
@@ -134,7 +134,7 @@ export class EpochsStore extends Store {
     const { result } = this.epochsApi.getEpochsInRangeQuery;
     return (
       result?.epochs
-        .filter(isNotNull)
+        .filter(isDefined)
         .map((e: EpochOverviewFragment) =>
           epochOverviewTransformer(e, this.networkInfo.store)
         ) ?? null
@@ -188,10 +188,6 @@ export class EpochsStore extends Store {
     >
   ): Promise<GetEpochsInRangeQuery | null> => {
     const { getEpochsInRangeQuery } = this.epochsApi;
-    // Wait for potential current execution (only supports one queued query)
-    if (getEpochsInRangeQuery.isExecuting) {
-      return null;
-    }
     return getEpochsInRangeQuery.execute(params);
   };
 
@@ -199,7 +195,7 @@ export class EpochsStore extends Store {
     epochs: GetEpochsInRangeQuery['epochs']
   ): IEpochOverview[] => {
     return epochs
-      .filter(isNotNull)
+      .filter(isDefined)
       .map((e: EpochOverviewFragment) =>
         epochOverviewTransformer(e, this.networkInfo.store)
       );

--- a/source/features/search/store.ts
+++ b/source/features/search/store.ts
@@ -2,7 +2,7 @@ import { action, computed, observable, runInAction } from 'mobx';
 import { ActionProps, createActionBindings } from '../../lib/ActionBinding';
 import Reaction, { createReactions } from '../../lib/mobx/Reaction';
 import { Store } from '../../lib/Store';
-import { isNotNull } from '../../lib/types';
+import { isDefined } from '../../lib/types';
 import { addressDetailTransformer } from '../address/api/transformers';
 import { ADDRESS_SEARCH_RESULT_PATH } from '../address/config';
 import { IAddressSummary } from '../address/types';
@@ -130,9 +130,9 @@ export class SearchStore extends Store {
     const result = await this.searchApi.searchByIdQuery.execute({
       id,
     });
-    if (result?.blocks.length > 0) {
+    if (result && result?.blocks.length > 0) {
       const blockData = result.blocks[0];
-      if (isNotNull(blockData)) {
+      if (isDefined(blockData)) {
         runInAction(() => {
           this.blockSearchResult = blockDetailsTransformer(blockData);
         });
@@ -141,9 +141,9 @@ export class SearchStore extends Store {
           query: { id },
         });
       }
-    } else if (result?.transactions.length > 0) {
+    } else if (result && result?.transactions.length > 0) {
       const txSearchResult = result.transactions[0];
-      if (isNotNull(txSearchResult)) {
+      if (isDefined(txSearchResult)) {
         runInAction(() => {
           this.transactionSearchResult = transactionDetailsTransformer(
             txSearchResult
@@ -205,7 +205,7 @@ export class SearchStore extends Store {
     const result = await this.searchApi.searchForAddressQuery.execute({
       address,
     });
-    if (isNotNull(result)) {
+    if (isDefined(result)) {
       runInAction(() => {
         this.addressSearchResult = addressDetailTransformer(address, result);
       });
@@ -242,7 +242,7 @@ export class SearchStore extends Store {
     );
     if (result) {
       const blockData = result.blocks[0];
-      if (isNotNull(blockData)) {
+      if (isDefined(blockData)) {
         runInAction(() => {
           this.blockSearchResult = blockDetailsTransformer(blockData);
         });
@@ -262,7 +262,7 @@ export class SearchStore extends Store {
     );
     if (result) {
       const epochData = result.epochs[0];
-      if (isNotNull(epochData)) {
+      if (isDefined(epochData)) {
         runInAction(() => {
           this.epochSearchResult = epochOverviewTransformer(
             epochData,

--- a/source/features/transactions/store.ts
+++ b/source/features/transactions/store.ts
@@ -1,7 +1,7 @@
 import { action, observable, runInAction } from 'mobx';
 import { ActionProps, createActionBindings } from '../../lib/ActionBinding';
 import { Store } from '../../lib/Store';
-import { isNotNull } from '../../lib/types';
+import { isDefined } from '../../lib/types';
 import { TransactionsApi } from './api';
 import { transactionDetailsTransformer } from './api/transformers';
 import { TransactionsActions } from './index';
@@ -45,7 +45,7 @@ export class TransactionsStore extends Store {
     if (result) {
       runInAction(() => {
         this.browsedAddressTransactions = result.transactions
-          .filter(isNotNull)
+          .filter(isDefined)
           .map(transactionDetailsTransformer);
       });
     }
@@ -64,7 +64,7 @@ export class TransactionsStore extends Store {
     if (result) {
       runInAction(() => {
         this.browsedBlockTransactions = result.transactions
-          .filter(isNotNull)
+          .filter(isDefined)
           .map(transactionDetailsTransformer);
       });
     }

--- a/source/lib/AbortablePromise.ts
+++ b/source/lib/AbortablePromise.ts
@@ -1,0 +1,60 @@
+export class AbortablePromise<TResult, TError> implements Promise<TResult> {
+  public static ABORT_ERROR = 'AbortError';
+
+  public readonly [Symbol.toStringTag]: string;
+  private isPending = true;
+  private promise: Promise<TResult>;
+  private resolve: (result: TResult) => void;
+  private reject: (error: any) => void;
+
+  constructor(promise: Promise<TResult>) {
+    this.promise = new Promise<TResult>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+      promise
+        .then(resolve)
+        .catch(reject)
+        .finally(() => {
+          this.isPending = false;
+        });
+    });
+  }
+
+  public then<TResult1 = TResult, TResult2 = never>(
+    onfulfilled?:
+      | ((value: TResult) => TResult1 | PromiseLike<TResult1>)
+      | undefined
+      | null,
+    onrejected?:
+      | ((reason: any) => TResult2 | PromiseLike<TResult2>)
+      | undefined
+      | null
+  ): Promise<TResult1 | TResult2> {
+    return this.promise.then(onfulfilled, onrejected);
+  }
+
+  public catch<TCaught = never>(
+    onrejected?:
+      | ((reason: TError) => TCaught | PromiseLike<TCaught>)
+      | undefined
+      | null
+  ): Promise<TResult | TCaught> {
+    return this.promise.catch(onrejected);
+  }
+
+  public finally(handler: () => void) {
+    return this.promise.finally(handler);
+  }
+
+  public abort() {
+    this.reject(AbortablePromise.ABORT_ERROR);
+  }
+
+  public get isExecuting() {
+    return this.isPending;
+  }
+
+  public get isDone() {
+    return !this.isPending;
+  }
+}

--- a/source/lib/mobx/react.ts
+++ b/source/lib/mobx/react.ts
@@ -10,13 +10,13 @@ import * as React from 'react';
  * Inspired by official recipe: https://mobx-react.js.org/recipes-effects
  *
  * @param effect
- * @param props
+ * @param observed
  */
 export function useObservableEffect<TProps>(
-  effect: (props: TProps | undefined) => void,
-  props?: TProps
+  effect: (observed: TProps) => void,
+  observed: TProps = {} as any
 ) {
-  const observableProps = props ? useAsObservableSource(props) : undefined;
+  const observableProps = useAsObservableSource(observed);
   React.useEffect(
     () => autorun(() => effect(observableProps)),
     [] // note empty dependencies

--- a/source/lib/types.ts
+++ b/source/lib/types.ts
@@ -4,7 +4,7 @@ import {
 } from 'next/dist/next-server/lib/utils';
 import React from 'react';
 
-export function isNotNull<T>(b: T | null): b is T {
+export function isDefined<T>(b: T | null | undefined): b is T {
   return b != null;
 }
 


### PR DESCRIPTION
Fixes #268 by simplifying the blocks browser render logic and debouncing the browse query (to avoid unnecessary calls when switching pages rapidly). This also reduces the executed queries to a minimum:

- One query immediately at first render
- Debounced query for page changes (query triggered after 400ms after last click)
- On the last page: one query after each block height / total items change (to support the trailing feature)