### PR TITLE
[issue-294] Fix tx display of in and output values

### DIFF
--- a/source/features/transactions/components/TransactionInfo.module.scss
+++ b/source/features/transactions/components/TransactionInfo.module.scss
@@ -110,10 +110,6 @@ $medium-breakpoint: 780px;
           margin-bottom: 5px;
           max-width: 244px;
           width: 100%;
-
-          &:last-child {
-            margin-bottom: 0;
-          }
         }
 
         .includedAt {

--- a/source/features/transactions/components/TransactionInfo.tsx
+++ b/source/features/transactions/components/TransactionInfo.tsx
@@ -147,9 +147,9 @@ const TransactionInfo = (props: ITransactionInfoProps) => {
             <div className={styles.totalOutput}>{props.totalOutput} ADA</div>
           </div>
           <div className={styles.infoRow}>
-            {props.outputs.map((output, i) => (
+            {props.inputs.map((input, i) => (
               <div key={i} className={styles.value}>
-                {output.value} ADA
+                {input.value} ADA
               </div>
             ))}
           </div>


### PR DESCRIPTION
This PR fixes the display of transaction inputs and ADA values to be in line with the design spec:
![grafik](https://user-images.githubusercontent.com/172414/80964223-c2615100-8e10-11ea-9d91-a9a0980cd904.png)
