### PR TITLE
Update to conform with Cardano GraphQL 1.0.0-rc.13 changes

### DIFF
--- a/.graphqlconfig
+++ b/.graphqlconfig
@@ -1,0 +1,22 @@
+{
+  "name": "Cardano GraphQL - Cardano DB Hasura Schema",
+  "schemaPath": "node_modules/@cardano-graphql/client-ts/api/cardano-db-hasura/schema.graphql",
+  "extensions": {
+    "endpoints": {
+      "Mainnet GraphQL Endpoint": {
+        "url": "https://cardano-graphql-mainnet.daedalus-operations.com",
+        "headers": {
+          "user-agent": "JS GraphQL"
+        },
+        "introspect": false
+      },
+      "Testnet GraphQL Endpoint": {
+        "url": "https://cardano-graphql-testnet.daedalus-operations.com",
+        "headers": {
+          "user-agent": "JS GraphQL"
+        },
+        "introspect": false
+      }
+    }
+  }
+}

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: ./node_modules/cardano-graphql-ts/schema.graphql
+schema: ./node_modules/@cardano-graphql/client-ts/api/cardano-db-hasura/schema.graphql
 documents: "source/**/*.graphql"
 generates:
   generated/typings/graphql-schema.d.ts:

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     }
   },
   "dependencies": {
+    "@cardano-graphql/client-ts": "^1.0.0-rc.13",
     "@types/react-addons-css-transition-group": "15.0.5",
     "browser-update": "3.3.9",
-    "cardano-graphql-ts": "1.0.0-rc.12",
     "cardano-js": "0.3.0",
     "chroma-js": "2.1.0",
     "classnames": "2.2.6",

--- a/source/config/jest.config.ts
+++ b/source/config/jest.config.ts
@@ -12,7 +12,9 @@ beforeAll(async () => {
       return graphqlClient.request(
         `query {
             cardano {
-              blockHeight
+              tip {
+                number
+              }
             }
           }
         `

--- a/source/features/blocks/ui/BlockList.tsx
+++ b/source/features/blocks/ui/BlockList.tsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc'
 import { isNumber } from 'lodash';
 import { observer } from 'mobx-react-lite';
 import React, { FC } from 'react';
@@ -9,6 +10,8 @@ import { LocalizedLink } from '../../navigation/ui/LocalizedLink';
 import { getBlockRoute } from '../helpers';
 import { IBlockOverview } from '../types';
 import styles from './BlockList.module.scss';
+
+dayjs.extend(utc)
 
 export interface IBlockListProps {
   ignoreLinksToEpoch?: boolean;
@@ -51,7 +54,7 @@ const columns = (
     },
     {
       cellValue: (row: IBlockOverview) =>
-        dayjs(row.createdAt).format('YYYY/MM/DD HH:mm:ss'),
+        dayjs.utc(row.createdAt).format('YYYY/MM/DD HH:mm:ss'),
       cssClass: 'createdAt',
       head: 'block.createdAtTitle',
       key: 'createdAt',

--- a/source/features/blocks/ui/BlockSummary.tsx
+++ b/source/features/blocks/ui/BlockSummary.tsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc'
 import { isNumber } from 'lodash';
 import { observer } from 'mobx-react-lite';
 import DividerWithTitle from '../../../widgets/divider-with-title/DividerWithTitle';
@@ -11,6 +12,8 @@ import { ITransactionDetails } from '../../transactions/types';
 import { BLOCK_SEARCH_RESULT_PATH } from '../config';
 import { IBlockDetailed } from '../types';
 import styles from './BlockSummary.module.scss';
+
+dayjs.extend(utc)
 
 export type BlockSummaryProps = {
   navigation?: NavigationActions;
@@ -102,7 +105,7 @@ const BlockSummary = (props: BlockSummaryProps) => {
               {translate('blockSummary.time')}
             </div>
             <div className={styles.infoValue}>
-              {dayjs(props.createdAt).format('YYYY/MM/DD HH:mm:ss')} UTC
+              {dayjs.utc(props.createdAt).format('YYYY/MM/DD HH:mm:ss')} UTC
             </div>
           </div>
           <div className={styles.infoRow}>

--- a/source/features/epochs/ui/EpochList.tsx
+++ b/source/features/epochs/ui/EpochList.tsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc'
 import { observer } from 'mobx-react-lite';
 import React, { FC } from 'react';
 import CircularProgress, {
@@ -10,6 +11,8 @@ import { LocalizedLink } from '../../navigation/ui/LocalizedLink';
 import { getEpochRoute } from '../helpers';
 import { IEpochOverview } from '../types';
 import styles from './EpochList.module.scss';
+
+dayjs.extend(utc)
 
 export interface IEpochListProps {
   currentEpoch: number;
@@ -60,14 +63,14 @@ const columns = (
   },
   {
     cellValue: (row: IEpochOverview) =>
-      dayjs(row.startedAt).format('YYYY/MM/DD HH:mm:ss'),
+      dayjs.utc(row.startedAt).format('YYYY/MM/DD HH:mm:ss'),
     cssClass: 'startedAt',
     head: 'epoch.startedAtTitle',
     key: 'startedAt',
   },
   {
     cellRender: (value: any) =>
-      dayjs(value.lastBlockAt).format('YYYY/MM/DD HH:mm:ss'),
+      dayjs.utc(value.lastBlockAt).format('YYYY/MM/DD HH:mm:ss'),
     cellValue: (row: IEpochOverview) => ({
       lastBlockAt: row.lastBlockAt,
     }),

--- a/source/features/epochs/ui/EpochSummary.tsx
+++ b/source/features/epochs/ui/EpochSummary.tsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc'
 import { observer } from 'mobx-react-lite';
 import CircularProgress, {
   CircularProgressSize,
@@ -7,6 +8,8 @@ import DividerWithTitle from '../../../widgets/divider-with-title/DividerWithTit
 import { useI18nFeature } from '../../i18n/context';
 import { IEpochOverview } from '../types';
 import styles from './EpochSummary.module.scss';
+
+dayjs.extend(utc)
 
 export interface IEpochSummaryProps {
   title: string;
@@ -48,7 +51,7 @@ const EpochSummary = ({ title, epoch }: IEpochSummaryProps) => {
               {translate('epochSummary.startedAt')}
             </div>
             <div className={styles.infoValue}>
-              {dayjs(epoch.startedAt).format('YYYY/MM/DD HH:mm:ss')}
+              {dayjs.utc(epoch.startedAt).format('YYYY/MM/DD HH:mm:ss')}
             </div>
           </div>
           <div className={styles.infoRow}>
@@ -56,7 +59,7 @@ const EpochSummary = ({ title, epoch }: IEpochSummaryProps) => {
               {translate('epochSummary.lastBlockAt')}
             </div>
             <div className={styles.infoValue}>
-              {dayjs(epoch.lastBlockAt).format('YYYY/MM/DD HH:mm:ss')}
+              {dayjs.utc(epoch.lastBlockAt).format('YYYY/MM/DD HH:mm:ss')}
             </div>
           </div>
           <div className={styles.infoRow}>

--- a/source/features/network-info/api/cardanoDynamic.graphql
+++ b/source/features/network-info/api/cardanoDynamic.graphql
@@ -1,17 +1,12 @@
 
 query cardanoDynamic {
   cardano {
-    blockHeight
+    tip {
+      number
+      slotWithinEpoch
+      createdAt
+    }
     currentEpoch {
-      blocks (
-        limit:1,
-        order_by: {
-          number: desc_nulls_last
-        }
-      ) {
-        slotWithinEpoch
-      }
-      lastBlockTime
       number
     }
   }

--- a/source/features/network-info/api/cardanoStatic.graphql
+++ b/source/features/network-info/api/cardanoStatic.graphql
@@ -2,8 +2,8 @@
 query cardanoStatic {
   cardano {
     networkName
-    protocolConst
     startTime
     slotDuration
+    slotsPerEpoch
   }
 }

--- a/source/features/network-info/specs/networkInfo.spec.ts
+++ b/source/features/network-info/specs/networkInfo.spec.ts
@@ -24,7 +24,7 @@ describe('Network information', () => {
     // 3. Access the observable search result provided by the store
     await waitForExpect(() => {
       expect(networkInfo.store.slotDuration).toBe(20000);
-      expect(networkInfo.store.protocolConst).toBe(2160);
+      expect(networkInfo.store.slotsPerEpoch).toBe(21600);
       expect(networkInfo.store.blockHeight).toBeGreaterThan(4000893);
       expect(networkInfo.store.currentEpoch).toBeGreaterThan(184);
     });

--- a/source/features/search/specs/searchForBlockById.spec.ts
+++ b/source/features/search/specs/searchForBlockById.spec.ts
@@ -25,7 +25,7 @@ describe('Searching for a block', () => {
       // 3. Access the observable search result provided by the store
       await waitForExpect(() => {
         expect(search.store?.blockSearchResult?.createdAt).toBe(
-          '2017-10-01T02:26:51'
+          '2017-10-01T02:26:51.000Z'
         );
         expect(search.store?.blockSearchResult?.transactionsCount).toBe('0');
       });

--- a/source/features/stake-pools/components/StakePoolTooltip.tsx
+++ b/source/features/stake-pools/components/StakePoolTooltip.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import utc from 'dayjs/plugin/utc'
 import React, { FC, useCallback, useEffect, useRef } from 'react';
 import { getColorFromRange } from '../../../lib/colors';
 import { useI18nFeature } from '../../i18n/context';
@@ -8,6 +9,7 @@ import { IStakePoolTooltipProps } from '../types';
 import styles from './StakePoolTooltip.module.scss';
 
 dayjs.extend(relativeTime);
+dayjs.extend(utc);
 const CloseCrossIcon = require('../../../public/assets/images/stake-pools/close-cross.svg');
 const ExternalLinkIcon = require('../../../public/assets/images/stake-pools/link-ic.svg');
 
@@ -31,7 +33,7 @@ const StakePoolTooltip: FC<IStakePoolTooltipProps> = ({
   const darken = 1;
   const alpha = 0.3;
   const reverse = true;
-  const retirementFromNow = retiring ? dayjs(retiring).fromNow(true) : '';
+  const retirementFromNow = retiring ? dayjs.utc(retiring).fromNow(true) : '';
   const colorBand = getColorFromRange(ranking);
 
   const colorBandStyle = {

--- a/source/features/transactions/components/TransactionInfo.tsx
+++ b/source/features/transactions/components/TransactionInfo.tsx
@@ -98,9 +98,7 @@ export interface ITransactionInfoProps extends ITransactionDetails {
 const TransactionInfo = (props: ITransactionInfoProps) => {
   const { translate } = useI18nFeature().store;
   const isMobile = window.innerWidth <= 768;
-  const includedAtUtc = dayjs.utc(
-    dayjs(props.includedAt).format('YYYY-MM-DD HH:mm:ss')
-  );
+  const includedAtUtc = dayjs.utc(props.includedAt)
   const onEpochNumberClick = (e: ITransactionDetails['block']['epoch']) => {
     if ((!e && e !== 0) || e === '-') {
       return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,6 +1438,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cardano-graphql/client-ts@^1.0.0-rc.13":
+  version "1.0.0-rc.13"
+  resolved "https://registry.yarnpkg.com/@cardano-graphql/client-ts/-/client-ts-1.0.0-rc.13.tgz#bf3bafc9b9b314a5c389dbbce6261ed09abbf91c"
+  integrity sha512-FEqNpUV7AzchsM4WooyEb9nNrgcDariLJiM+JXV/WyoLa4WKb6md1IttKuub+XrHixRcB7ZwmaFm+nhUV2kmcg==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -4622,11 +4627,6 @@ capture-stack-trace@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
   integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
-
-cardano-graphql-ts@1.0.0-rc.12:
-  version "1.0.0-rc.12"
-  resolved "https://registry.yarnpkg.com/cardano-graphql-ts/-/cardano-graphql-ts-1.0.0-rc.12.tgz#943292f4c0b3f650d5199146d725a239e3dc0788"
-  integrity sha512-qZ5MhgssL+dz50IB/UjYHzreHnQcS3pgTHaMTtXTG0xGBYuBoJchMK6tgrP2SLNFqnb5j93mAVMQor8+sWOhKQ==
 
 cardano-js@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
- Cardano GraphQL now returns dates as [ISO 3339](https://tools.ietf.org/html/rfc3339), whereas previously it just passed through the UTC string from the DB. The previous behaviour of `new Date(startDate)` would produce the desired outcome, but only for lack of additional meta for it to know any better. When calling `new Date(isoString)`, local server time is produced, so we need to specify a shift to UTC when applying it in the UI.

- Also accesses new `Cardano.tip` and `Cardano.slotsPerEpoch` to support Shelley networks and simplify the query.
- Also adds .graphqlconfig pointing at the package schema