### PR TITLE
fix: Hardens the slot leader formatting

### DIFF
--- a/source/features/blocks/api/transformers.ts
+++ b/source/features/blocks/api/transformers.ts
@@ -51,15 +51,18 @@ export const blockDetailsTransformer = (
 });
 
 function formatCreatedBy(value: IBlockOverview['createdBy']): string {
-  switch (value.substring(0, 13)) {
-    case 'ByronGenesis-':
-      return value.substring(13, 21);
-    case 'Epoch boundar':
-      return 'EBB';
-    case 'Genesis slot ':
+
+  switch (value) {
+    case 'Genesis slot leader':
       return 'Genesis';
+    case 'Epoch boundary slot leader':
+      return 'EBB';
     default:
-      throw new Error('Unexpected IBlockOverview.createdBy value');
+      const selection =  value.split('-');
+      if (!Array.isArray(selection)) {
+        return ''
+      }
+      return selection[1].substring(0,7)
   }
 }
 

--- a/source/features/search/specs/searchForBlockById.spec.ts
+++ b/source/features/search/specs/searchForBlockById.spec.ts
@@ -25,7 +25,7 @@ describe('Searching for a block', () => {
       // 3. Access the observable search result provided by the store
       await waitForExpect(() => {
         expect(search.store?.blockSearchResult?.createdAt).toBe(
-          '2017-10-01T02:26:51.000Z'
+          '2017-10-01T02:26:51Z'
         );
         expect(search.store?.blockSearchResult?.transactionsCount).toBe('0');
       });


### PR DESCRIPTION
Simplifies the logic relating to the formatting of slot leader descriptions, fixing a bug with the software running in the Shelley era