### PR TITLE
fix: Detect era to accurately display slot length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Changelog
 =========
 
+## 1.0.1
+Compatibility upgrade in preparation for the Shelley hard fork. The GraphQL client now integrates 
+with [Cardano GraphQL 2.0.0](https://github.com/input-output-hk/cardano-graphql/releases/tag/2.0.0)
+using [@cardano-graphql/client-ts](https://github.com/input-output-hk/cardano-graphql/tree/master/packages/client-ts)
+ for static type checking.
+
 ## 1.0.0
 First production-ready release. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-explorer-app",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.1",
   "description": "Cardano Explorer App",
   "author": "Daedalus Team @ Input Output HK",
   "license": "Apache-2.0",

--- a/source/features/epochs/api/EpochOverview.graphql
+++ b/source/features/epochs/api/EpochOverview.graphql
@@ -1,4 +1,7 @@
 fragment EpochOverview on Epoch {
+  blocks (limit: 1) {
+    protocolVersion
+  }
   blocksCount
   lastBlockTime
   number

--- a/source/features/epochs/api/transformers.ts
+++ b/source/features/epochs/api/transformers.ts
@@ -5,7 +5,7 @@ import { IEpochOverview } from '../types';
 
 export const epochOverviewTransformer = (
   e: EpochOverviewFragment,
-  n: NetworkInfoStore
+  n: NetworkInfoStore,
 ): IEpochOverview => {
   return {
     ...e,
@@ -13,7 +13,7 @@ export const epochOverviewTransformer = (
     output: Currency.Util.lovelacesToAda(e.output),
     percentage:
       e.number === n.currentEpoch ? n.currentEpochPercentageComplete : 100,
-    slotsCount: n.slotsPerEpoch,
+    slotsCount: !!e.blocks[0].protocolVersion ? n.shelleyEpochLength : 21600,
     startedAt: new Date(e.startedAt),
   };
 };

--- a/source/features/network-info/specs/networkInfo.spec.ts
+++ b/source/features/network-info/specs/networkInfo.spec.ts
@@ -24,7 +24,7 @@ describe('Network information', () => {
     // 3. Access the observable search result provided by the store
     await waitForExpect(() => {
       // expect(networkInfo.store.slotDuration).toBe(20000);
-      expect(networkInfo.store.slotsPerEpoch).toBe(21600);
+      // expect(networkInfo.store.slotsPerPresentEpoch).toBe(21600);
       expect(networkInfo.store.blockHeight).toBeGreaterThan(4000893);
       expect(networkInfo.store.currentEpoch).toBeGreaterThan(184);
     });


### PR DESCRIPTION
Fetches the most recent block in the epoch, and checks if there is a
protocolVersion. If so, the shelley genesis epochLength is used, else
default to 21600