### PR TITLE
fix(search): Invert search input introspection 

### DIFF
--- a/source/features/search/store.ts
+++ b/source/features/search/store.ts
@@ -206,6 +206,12 @@ export class SearchStore extends Store {
       address,
     });
     if (isDefined(result)) {
+      if (
+        result.transactions_aggregate.aggregate?.count === '0' &&
+        result.utxos_aggregate.aggregate?.sum.value === null
+      ) {
+        return this.searchActions.unknownSearchRequested.trigger({ query: address })
+      }
       runInAction(() => {
         this.addressSearchResult = addressDetailTransformer(address, result);
       });

--- a/source/features/search/ui/SearchBar.tsx
+++ b/source/features/search/ui/SearchBar.tsx
@@ -1,16 +1,10 @@
-import { Address } from 'cardano-js';
-import { AddressGroup } from 'cardano-js/dist/Address/AddressGroup';
-import { ChainSettings } from 'cardano-js/dist/ChainSettings';
 import cx from 'classnames';
 import { useState } from 'react';
 import React from 'react';
 import {
   BrandType,
-  CardanoEra,
-  CardanoNetwork,
   SearchType,
 } from '../../../constants';
-import { environment } from '../../../environment';
 import { useI18nFeature } from '../../i18n/context';
 import { useNetworkInfoFeature } from '../../network-info/context';
 import { useSearchFeature } from '../context';
@@ -30,21 +24,7 @@ export const SearchBar = (props: ISearchBarProps) => {
   const networkInfo = useNetworkInfoFeature().store;
   const introspectQuery = (query: string, type?: string) => {
     const typeOfSearch = type ? type : searchType;
-    const chainSettings =
-      environment.CARDANO.NETWORK === CardanoNetwork.MAINNET
-        ? ChainSettings.mainnet
-        : ChainSettings.testnet;
-    // Assuming the AddressGroup.jormungandr is the format for Shelley addresses
-    // Will update when final decision is made.
-    const addressGroup =
-      environment.CARDANO.ERA === CardanoEra.BYRON
-        ? AddressGroup.byron
-        : AddressGroup.jormungandr;
-    if (Address.Util.isAddress(query, chainSettings, addressGroup)) {
-      search.actions.addressSearchRequested.trigger({
-        address: query,
-      });
-    } else if (query?.length === 64) {
+    if (query?.length === 64) {
       search.actions.idSearchRequested.trigger({ id: query });
     } else if (/^\d+$/.test(query)) {
       const searchNumber = parseInt(query, 10);
@@ -65,7 +45,9 @@ export const SearchBar = (props: ISearchBarProps) => {
         }
       }
     } else {
-      search.actions.unknownSearchRequested.trigger({ query });
+      search.actions.addressSearchRequested.trigger({
+        address: query,
+      });
     }
   };
 
@@ -96,8 +78,8 @@ export const SearchBar = (props: ISearchBarProps) => {
     <>
       <Search
         brandType={props.brandType}
-        onInputChange={(query) => setSearchValue(query)}
-        onSearch={(query) => introspectQuery(query)}
+        onInputChange={(query) => setSearchValue(query.trim())}
+        onSearch={(query) => introspectQuery(query.trim())}
         onRemoveSearchType={removeSearchType}
         placeholder={translate('search.placeholder') as string}
         title={translate('search.title') as string}


### PR DESCRIPTION
We currently have no simple way to introspect strings in the browser, so this PR simply checks for a hash length, then falls through to assume the input is an address.

Closes #342

## Acceptance Criteria
1. Addresses from Byron era and Shelley era can be searched
2. Transactions and blocks can be searched by ID
3. Invalid strings show the not found page
