### PR TITLE
[issue-335] Split slots & blocks into separate columns

### DIFF
--- a/source/features/epochs/ui/EpochList.module.scss
+++ b/source/features/epochs/ui/EpochList.module.scss
@@ -12,8 +12,9 @@
       }
     }
 
-    .blocksSlots {
-      width: 120px;
+    .blocks,
+    .slots {
+      width: 60px;
     }
 
     .startedAt {

--- a/source/features/epochs/ui/EpochList.tsx
+++ b/source/features/epochs/ui/EpochList.tsx
@@ -55,11 +55,16 @@ const columns = (
     key: 'number',
   },
   {
-    cellValue: (row: IEpochOverview) =>
-      `${row.blocksCount} / ${row.slotsCount}`,
-    cssClass: 'blocksSlots',
-    head: 'epoch.blocksSlotTitle',
-    key: 'blocksSlots',
+    cellValue: (row: IEpochOverview) => row.slotsCount,
+    cssClass: 'slots',
+    head: 'epoch.slotsTitle',
+    key: 'slots',
+  },
+  {
+    cellValue: (row: IEpochOverview) => row.blocksCount,
+    cssClass: 'blocks',
+    head: 'epoch.blocksTitle',
+    key: 'blocks',
   },
   {
     cellValue: (row: IEpochOverview) =>

--- a/source/features/i18n/translations/de.json
+++ b/source/features/i18n/translations/de.json
@@ -43,7 +43,8 @@
     "epochsListTitle": "Epochen Suchen"
   },
   "epoch": {
-    "blocksSlotTitle": "Blöcke / Slots",
+    "blocksTitle": "Blöcke",
+    "slotsTitle": "Slots",
     "createdByTitle": "Erzeugt von",
     "epochTitle": "Epoche",
     "lastBlockAtTitle": "Letzter Block",

--- a/source/features/i18n/translations/en.json
+++ b/source/features/i18n/translations/en.json
@@ -43,7 +43,8 @@
     "epochsListTitle": "Browse Epochs"
   },
   "epoch": {
-    "blocksSlotTitle": "Blocks / Slots",
+    "blocksTitle": "Blocks",
+    "slotsTitle": "Slots",
     "createdByTitle": "Created By",
     "epochTitle": "Epoch",
     "lastBlockAtTitle": "Last Block at",

--- a/source/features/i18n/translations/ja.json
+++ b/source/features/i18n/translations/ja.json
@@ -43,7 +43,8 @@
     "epochsListTitle": "エポックを閲覧する"
   },
   "epoch": {
-    "blocksSlotTitle": "ブロック/スロット",
+    "blocksTitle": "ブロック",
+    "slotsTitle": "スロット",
     "createdByTitle": "生成者",
     "epochTitle": "エポック",
     "lastBlockAtTitle": "最終ブロック",


### PR DESCRIPTION
This PR fixes #335 by splitting slots and blocks counts into separate columns in the epoch list table. This should reduce potential confusion about Shelley slots & and blocks not necessarily matching in numbers (and thus assuming bad performance of the Cardano network, although these metrics are not valid indicators anymore):

![CleanShot 2020-08-06 at 21 53 07](https://user-images.githubusercontent.com/172414/89576735-f3965680-d82f-11ea-89eb-51b1df1acb56.png)

![CleanShot 2020-08-06 at 21 58 54](https://user-images.githubusercontent.com/172414/89576822-16c10600-d830-11ea-8d0e-4b744449c9ff.png)

![CleanShot 2020-08-06 at 21 59 08](https://user-images.githubusercontent.com/172414/89576833-188ac980-d830-11ea-86cb-ff8aaf95b76c.png)