### PR TITLE
[SRE-134] Update to latest react-polymorph

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-ga": "2.7.0",
     "react-i18next": "11.3.3",
     "react-no-ssr": "1.1.0",
-    "react-polymorph": "0.9.3-rc.1",
+    "react-polymorph": "0.9.5-rc.1",
     "react-ssr-prepass": "npm:preact-ssr-prepass@1.0.1",
     "store": "2.0.12"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7002,6 +7002,11 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-password-entropy@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fast-password-entropy/-/fast-password-entropy-1.1.1.tgz#47ba9933095fd5a32fb184915fc8e76ee19cf429"
+  integrity sha512-dxm29/BPFrNgyEDygg/lf9c2xQR0vnQhG7+hZjAI39M/3um9fD4xiqG6F0ZjW6bya5m9CI0u6YryHGRtxCGCiw==
+
 fast-url-parser@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/fast-url-parser/-/fast-url-parser-1.1.3.tgz#f4af3ea9f34d8a271cf58ad2b3759f431f0b318d"
@@ -11606,11 +11611,6 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.1
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postinstall-build@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postinstall-build/-/postinstall-build-5.0.1.tgz#b917a9079b26178d9a24af5a5cd8cb4a991d11b9"
-  integrity sha1-uRepB5smF42aJK9aXNjLSpkdEbk=
-
 preact-render-to-string@5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.1.4.tgz#f26171f58f0e93b36236e4b0bee62ce561120b7c"
@@ -12204,15 +12204,15 @@ react-no-ssr@1.1.0:
   dependencies:
     babel-runtime "6.x.x"
 
-react-polymorph@0.9.3-rc.1:
-  version "0.9.3-rc.1"
-  resolved "https://registry.yarnpkg.com/react-polymorph/-/react-polymorph-0.9.3-rc.1.tgz#eccbe47cc231980b3fc31578044ee58c96588ae0"
-  integrity sha512-QrgxOWqryX/ZaOkkUfPHkAEThw7kACDkyQLokArWyRka4WW2t90FCgAMriw6Oo9e63D++fhJ6BJyW476JEkYtA==
+react-polymorph@0.9.5-rc.1:
+  version "0.9.5-rc.1"
+  resolved "https://registry.yarnpkg.com/react-polymorph/-/react-polymorph-0.9.5-rc.1.tgz#4631fa3d35d485291db3e6a501da0d2c2db3368c"
+  integrity sha512-zD4jeeYwnYcatgA/ynuLbyCJ8jWlePtGj/7GjblH/F7OH4qMLd21p0E3ThxkxN5pVkqBtLQRR2YtgWpt7ZpWCw==
   dependencies:
     create-react-context "0.2.2"
     create-react-ref "0.1.0"
+    fast-password-entropy "1.1.1"
     filter-react-dom-props "0.0.2"
-    postinstall-build "5.0.1"
     react-modal "3.1.12"
     react-scrollbars-custom "4.0.21"
 


### PR DESCRIPTION
The latest react-polymorph version removed the deprecated postinstall-build package.

You can see the related changes here:
https://github.com/input-output-hk/react-polymorph/pull/146