### PR TITLE
feat: show deposits and reclaims when present in transaction

### DIFF
--- a/source/features/i18n/translations/de.json
+++ b/source/features/i18n/translations/de.json
@@ -152,6 +152,8 @@
   "transaction": {
     "block": "Block",
     "confirmations": "Konfirmationen",
+    "deposit": "Kaution",
+    "depositReclaim": "Kautionsrückforderung",
     "epoch": "Epoche",
     "fee": "Transaktionsgebühr",
     "from": "Input-Adressen",

--- a/source/features/i18n/translations/en.json
+++ b/source/features/i18n/translations/en.json
@@ -153,6 +153,8 @@
   "transaction": {
     "block": "Block",
     "confirmations": "Confirmations",
+    "deposit": "Deposit",
+    "depositReclaim": "Deposit Reclaim",
     "epoch": "Epoch",
     "fee": "Transaction Fee",
     "from": "From addresses",

--- a/source/features/i18n/translations/ja.json
+++ b/source/features/i18n/translations/ja.json
@@ -152,6 +152,8 @@
   "transaction": {
     "block": "ブロック",
     "confirmations": "確認",
+    "deposit": "デポジット",
+    "depositReclaim": "デポジットの返還",
     "epoch": "エポック",
     "fee": "トランザクション手数料",
     "from": "送信元",

--- a/source/features/transactions/api/TransactionDetails.graphql
+++ b/source/features/transactions/api/TransactionDetails.graphql
@@ -5,6 +5,7 @@ fragment TransactionDetails on Transaction {
     number,
     slotNo,
   }
+  deposit,
   fee,
   hash,
   includedAt,

--- a/source/features/transactions/api/transformers.ts
+++ b/source/features/transactions/api/transformers.ts
@@ -11,6 +11,7 @@ export const transactionDetailsTransformer = (
     id: tx.block?.hash,
     number: tx.block?.number,
   },
+  deposit: Currency.Util.lovelacesToAda(tx.deposit),
   fee: Currency.Util.lovelacesToAda(tx.fee),
   id: tx.hash,
   includedAt: new Date(tx.includedAt),

--- a/source/features/transactions/components/TransactionInfo.tsx
+++ b/source/features/transactions/components/TransactionInfo.tsx
@@ -119,7 +119,7 @@ const TransactionInfo = (props: ITransactionInfoProps) => {
     });
   };
   const epoch = props.block.epoch === '-' ? 0 : props.block.epoch;
-
+  const depositLabel = parseInt(props.deposit) >= 0 ? 'transaction.deposit' : 'transaction.depositReclaim'
   return (
     <div className={styles.root}>
       {props.title && (
@@ -226,6 +226,16 @@ const TransactionInfo = (props: ITransactionInfoProps) => {
           />
         </div>
       </div>
+
+      {/* ===== DEPOSIT ===== */}
+      {props.deposit !== '0' && (
+        <div className={styles.row}>
+          <div className={styles.label}>
+            {translate(depositLabel)}
+          </div>
+          <div className={styles.value}>{Math.abs(parseInt(props.deposit))} ADA</div>
+        </div>
+      )}
 
       {/* ===== TOTAL OUTPUT ===== */}
 

--- a/source/features/transactions/types.ts
+++ b/source/features/transactions/types.ts
@@ -20,6 +20,7 @@ export interface ITransactionDetails {
     number?: number | null;
     slot?: number | null;
   };
+  deposit: string;
   fee: string;
   id: string;
   includedAt: Date;


### PR DESCRIPTION
Shows Deposit or Deposit Reclaim in the `TransactionInfo` when present in
transaction

Closes #353

![Screenshot from 2020-09-19 00-27-40](https://user-images.githubusercontent.com/303881/93610184-1790ae80-fa10-11ea-901d-6d0e98b42dd3.png)
![Screenshot from 2020-09-19 00-27-28](https://user-images.githubusercontent.com/303881/93610202-1cedf900-fa10-11ea-906e-2224dde69098.png)
![Screenshot from 2020-09-19 01-02-59](https://user-images.githubusercontent.com/303881/93613234-f0d47700-fa13-11ea-8559-3caf727c4997.png)
