### PR TITLE
feat: use stake pool hash over slot leader reference

### DIFF
--- a/source/features/blocks/api/BlockOverview.graphql
+++ b/source/features/blocks/api/BlockOverview.graphql
@@ -2,6 +2,9 @@ fragment BlockOverview on Block {
   forgedAt
   slotLeader {
     description
+    stakePool {
+      hash
+    }
   }
   epochNo,
   hash

--- a/source/features/blocks/api/transformers.ts
+++ b/source/features/blocks/api/transformers.ts
@@ -16,10 +16,13 @@ export const blockOverviewTransformer = (
   } else {
     epoch = b.epochNo;
   }
+  const createdBy = b.slotLeader.stakePool?.hash !== undefined ?
+    shortenCreatedBy(b.slotLeader.stakePool.hash) :
+    formatSlotLeaderDescription(b.slotLeader.description)
   return {
     ...b,
     createdAt: b.forgedAt,
-    createdBy: formatCreatedBy(b.slotLeader.description),
+    createdBy,
     epoch,
     id: b.hash,
     number: b.number || '-',
@@ -50,7 +53,11 @@ export const blockDetailsTransformer = (
     .map(transactionDetailsTransformer),
 });
 
-function formatCreatedBy(value: IBlockOverview['createdBy']): string {
+function shortenCreatedBy (createdBy: string) {
+  return createdBy.substring(0, 7)
+}
+
+function formatSlotLeaderDescription (value: IBlockOverview['createdBy']): string {
   switch (value) {
     case 'Genesis slot leader':
       return 'Genesis';
@@ -61,7 +68,7 @@ function formatCreatedBy(value: IBlockOverview['createdBy']): string {
       if (!Array.isArray(selection)) {
         return '';
       }
-      return selection[1].substring(0, 7);
+      return shortenCreatedBy(selection[1]);
   }
 }
 


### PR DESCRIPTION
# Context
Closes #355

# Proposed Solution
when a block is created by a stake pool, the pool hash is now used. BFT
nodes still use the slot leader reference

![screenshot_pooltool](https://user-images.githubusercontent.com/303881/93893739-546ee500-fd31-11ea-9dbe-366a573ea77b.png)
![screenshot_explorer](https://user-images.githubusercontent.com/303881/93893746-5769d580-fd31-11ea-8d66-b39243f8b256.png)
![screenshot_explorer_detail](https://user-images.githubusercontent.com/303881/93893752-589b0280-fd31-11ea-91f0-52a29bb0a8c4.png)
