### PR TITLE
Revert "feat: use stake pool hash over slot leader reference"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ Changelog
 - [show deposits and reclaims when present in transaction](https://github.com/input-output-hk/cardano-explorer-app/pull/361)
 - [add withdrawals to TransactionInfo](https://github.com/input-output-hk/cardano-explorer-app/pull/363)
 - [resolve stake address searches based on withdrawals](https://github.com/input-output-hk/cardano-explorer-app/pull/363)
-- [use stake pool hash over slot leader reference](https://github.com/input-output-hk/cardano-explorer-app/pull/364)
 ### Chores
 - [use new combined cardano-graphql schema from client package, removing local build step](https://github.com/input-output-hk/cardano-explorer-app/pull/362)
 

--- a/source/features/blocks/api/BlockOverview.graphql
+++ b/source/features/blocks/api/BlockOverview.graphql
@@ -2,9 +2,6 @@ fragment BlockOverview on Block {
   forgedAt
   slotLeader {
     description
-    stakePool {
-      hash
-    }
   }
   epochNo,
   hash

--- a/source/features/blocks/api/transformers.ts
+++ b/source/features/blocks/api/transformers.ts
@@ -16,13 +16,10 @@ export const blockOverviewTransformer = (
   } else {
     epoch = b.epochNo;
   }
-  const createdBy = b.slotLeader.stakePool?.hash !== undefined ?
-    shortenCreatedBy(b.slotLeader.stakePool.hash) :
-    formatSlotLeaderDescription(b.slotLeader.description)
   return {
     ...b,
     createdAt: b.forgedAt,
-    createdBy,
+    createdBy: formatCreatedBy(b.slotLeader.description),
     epoch,
     id: b.hash,
     number: b.number || '-',
@@ -53,11 +50,7 @@ export const blockDetailsTransformer = (
     .map(transactionDetailsTransformer),
 });
 
-function shortenCreatedBy (createdBy: string) {
-  return createdBy.substring(0, 7)
-}
-
-function formatSlotLeaderDescription (value: IBlockOverview['createdBy']): string {
+function formatCreatedBy(value: IBlockOverview['createdBy']): string {
   switch (value) {
     case 'Genesis slot leader':
       return 'Genesis';
@@ -68,7 +61,7 @@ function formatSlotLeaderDescription (value: IBlockOverview['createdBy']): strin
       if (!Array.isArray(selection)) {
         return '';
       }
-      return shortenCreatedBy(selection[1]);
+      return selection[1].substring(0, 7);
   }
 }
 


### PR DESCRIPTION
This reverts commit 0f345dd2

This change exposes a potential issue with the GraphQL client library, which is not yet fully understood, however should not hold up the release. We will revisit later with the larger update for stake pool information