### PR TITLE
chore: add Ada supply queries for inclusion in the allow-list

### DIFF
--- a/source/features/ada-supply/all.graphql
+++ b/source/features/ada-supply/all.graphql
@@ -1,0 +1,9 @@
+{
+  ada {
+    supply {
+      circulating
+      max
+      total
+    }
+  }
+}

--- a/source/features/ada-supply/circulating-max.graphql
+++ b/source/features/ada-supply/circulating-max.graphql
@@ -1,0 +1,8 @@
+{
+  ada {
+    supply {
+      circulating
+      max
+    }
+  }
+}

--- a/source/features/ada-supply/circulating-total.graphql
+++ b/source/features/ada-supply/circulating-total.graphql
@@ -1,0 +1,8 @@
+{
+  ada {
+    supply {
+      circulating
+      total
+    }
+  }
+}

--- a/source/features/ada-supply/circulating.graphql
+++ b/source/features/ada-supply/circulating.graphql
@@ -1,0 +1,7 @@
+{
+  ada {
+    supply {
+      circulating
+    }
+  }
+}

--- a/source/features/ada-supply/max-total.graphql
+++ b/source/features/ada-supply/max-total.graphql
@@ -1,0 +1,8 @@
+{
+  ada {
+    supply {
+      max
+      total
+    }
+  }
+}

--- a/source/features/ada-supply/max.graphql
+++ b/source/features/ada-supply/max.graphql
@@ -1,0 +1,7 @@
+{
+  ada {
+    supply {
+      max
+    }
+  }
+}

--- a/source/features/ada-supply/total.graphql
+++ b/source/features/ada-supply/total.graphql
@@ -1,0 +1,7 @@
+{
+  ada {
+    supply {
+      total
+    }
+  }
+}


### PR DESCRIPTION
There are currently no features in the application, but this change
will enable API access to the ada.supply information in the next update of `cardano-graphql`