### PR TITLE
fix: remove stray acute character

### DIFF
--- a/source/features/transactions/components/TransactionTokenList.tsx
+++ b/source/features/transactions/components/TransactionTokenList.tsx
@@ -42,7 +42,7 @@ const TokenList = (props: { tokens: IToken[]; }) => {
                 setIsVisible(false);
               }}
               className={styles.token}
-            >`
+            >
               {`${t.quantity} ${addEllipsis(t.asset.fingerprint, 9, 4)}`}{' '}
             </span>
           ))}


### PR DESCRIPTION
There's a stray character in the list component:

![image](https://user-images.githubusercontent.com/303881/109590354-ef30e280-7b5f-11eb-932b-535a51ba1911.png)
