### PR TITLE
feature: add query to support fetching transaction metadata

### DIFF
--- a/source/environment.ts
+++ b/source/environment.ts
@@ -7,10 +7,10 @@ export const environment = {
   CARDANO: {
     ERA: (process.env.CARDANO_ERA as CardanoEra) || CardanoEra.BYRON,
     GRAPHQL: {
-      HTTP_URL: `${process.env.GRAPHQL_API_PROTOCOL || 'https'}://${
+      HTTP_URL: `${process.env.GRAPHQL_API_PROTOCOL || 'http'}://${
         process.env.GRAPHQL_API_HOST ||
-        'cardano-graphql-mainnet.daedalus-operations.com'
-      }:${process.env.GRAPHQL_API_PORT || '443'}/${
+        'localhost'
+      }:${process.env.GRAPHQL_API_PORT || '3100'}/${
         process.env.GRAPHQL_API_PATH || ''
       }`,
     },

--- a/source/features/transactions/api/README.md
+++ b/source/features/transactions/api/README.md
@@ -1,0 +1,1 @@
+transactionMetadata is present to be included in the list of allowed queries.

--- a/source/features/transactions/api/transactionMetadata.graphql
+++ b/source/features/transactions/api/transactionMetadata.graphql
@@ -1,0 +1,18 @@
+query transactionMetadata(
+  $hashes: [Hash32Hex!]!
+) {
+  transactions(
+    where: {
+      hash: {
+        _in: $hashes
+      }
+    }
+  ) {
+    hash
+    metadata {
+      key
+      value
+    }
+  }
+}
+


### PR DESCRIPTION
Accepts an array of transaction hashes, returns just the metadata
and reflects the hash.