### PR TITLE
[DDW-633] Ask startedAt field of reward epoch

### DIFF
--- a/source/features/rewards/api/getRewardsForAddresses.graphql
+++ b/source/features/rewards/api/getRewardsForAddresses.graphql
@@ -14,6 +14,7 @@ query getRewardsForAddresses (
     amount
     earnedIn {
       number
+      startedAt
     }
     stakePool {
       id


### PR DESCRIPTION
In order to implement [[DDW-633] Implement earned rewards history](https://github.com/input-output-hk/daedalus/pull/2572) in Daedalus we need to add the `startedAt` field of the reward epoch so we can display the reward date/time.