### PR TITLE
Update twitter handle from the footer

### DIFF
--- a/source/widgets/layout/Footer.tsx
+++ b/source/widgets/layout/Footer.tsx
@@ -146,7 +146,7 @@ export const Footer = (props: IFooterProps) => {
                   </a>
                 </li>
                 <li>
-                  <a href={'https://twitter.com/CardanoStiftung'}>
+                  <a href={'https://twitter.com/Cardano_CF'}>
                     {translate('footer.cardanoFoundationTwitter')}
                   </a>
                 </li>


### PR DESCRIPTION
## 📚  Description

The current Twitter handle for the Cardano Foundation in the footer points to https://twitter.com/CardanoStiftung
This PR is to update the Twitter handle to point to the good one: https://twitter.com/Cardano_CF

<img width="701" alt="Screenshot 2022-10-02 at 20 32 41" src="https://user-images.githubusercontent.com/5256287/193470226-a005b90d-c723-44bc-be49-801ff0b5124c.png">

<img width="700" alt="Screenshot 2022-10-02 at 20 33 18" src="https://user-images.githubusercontent.com/5256287/193470248-afd21c51-9204-4903-8c20-54a0d2463515.png">

